### PR TITLE
#12 Fix typo in Atum.getControMeasure

### DIFF
--- a/atum/src/main/scala/za/co/absa/atum/core/Atum.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/Atum.scala
@@ -65,8 +65,19 @@ object Atum {
 
   /**
     * Returns the current control measures object containing all the checkpoints up to the current point.
+    *
+    * @deprecated This method is deprecated. Please use getControlMeasure
     */
+  @Deprecated
   def getControMeasure: ControlMeasure = {
+    preventNotInitialized()
+    controlFrameworkState.getControlMeasure
+  }
+
+  /**
+    * Returns the current control measures object containing all the checkpoints up to the current point.
+    */
+  def getControlMeasure: ControlMeasure = {
     preventNotInitialized()
     controlFrameworkState.getControlMeasure
   }


### PR DESCRIPTION
This fix is done by deprecating the previous wrong method and creating a new one with correct spelling. I did not change the previous to call the new one, because I think this breaks standards of deprecation.

I have tried writing tests for it but the Atum object is such a complex thing that actually has no accesor to its vars that I was unable to. (I even think this breaks TDD principles)

Plus - now there is something called scalatestplus and I just lost a bunch of time on that.