### PR TITLE
Hotfix/win publish

### DIFF
--- a/atum/pom.xml
+++ b/atum/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>za.co.absa</groupId>
 		<artifactId>atum-parent</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
+		<version>3.0.0</version>
 	</parent>
 
 

--- a/atum/pom.xml
+++ b/atum/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>za.co.absa</groupId>
 		<artifactId>atum-parent</artifactId>
-		<version>3.0.0</version>
+		<version>3.0.1-SNAPSHOT</version>
 	</parent>
 
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>za.co.absa</groupId>
 		<artifactId>atum-parent</artifactId>
-		<version>3.0.0</version>
+		<version>3.0.1-SNAPSHOT</version>
 	</parent>
 
 	<dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>za.co.absa</groupId>
 		<artifactId>atum-parent</artifactId>
-		<version>0.3.0-SNAPSHOT</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>za.co.absa</groupId>
     <artifactId>atum-parent</artifactId>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -66,7 +66,7 @@
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
         <url>${scm.url}</url>
-        <tag>v3.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
         <!-- Overridable SCM properties to support multiple SCM URLs-->
         <scm.connection>scm:git:git://github.com/AbsaOSS/atum.git</scm.connection>
-        <scm.developerConnection>scm:git:ssh://github.com/AbsaOSS/atum.git</scm.developerConnection>
+        <scm.developerConnection>scm:git:ssh://git@github.com/AbsaOSS/atum.git</scm.developerConnection>
         <scm.url>http://github.com/AbsaOSS/atum/tree/master</scm.url>
 
         <!-- Frameworks and libraries -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>za.co.absa</groupId>
     <artifactId>atum-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>3.0.0</version>
 
     <packaging>pom</packaging>
 
@@ -66,7 +66,7 @@
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
         <url>${scm.url}</url>
-        <tag>HEAD</tag>
+        <tag>v3.0.0</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
In order to successfully release v3.0.0, the following change had to be made
 - enforcing 'git' username, because otherwise local user name on Win is used (and that of course fails)