### PR TITLE
Release/3.3.0 + release version consolidation

### DIFF
--- a/atum-s3-sdk-extension/pom.xml
+++ b/atum-s3-sdk-extension/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1-SNAPSHOT</version>
     </parent>
 
     <dependencyManagement>

--- a/atum-s3-sdk-extension/pom.xml
+++ b/atum-s3-sdk-extension/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0</version>
     </parent>
 
     <dependencyManagement>

--- a/atum/pom.xml
+++ b/atum/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0</version>
     </parent>
 
     <dependencies>

--- a/atum/pom.xml
+++ b/atum/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/examples-s3-sdk-extension/pom.xml
+++ b/examples-s3-sdk-extension/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0</version>
     </parent>
 
     <dependencies>

--- a/examples-s3-sdk-extension/pom.xml
+++ b/examples-s3-sdk-extension/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0</version>
     </parent>
 
     <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.2.1-SNAPSHOT</version>
+        <version>3.3.0</version>
     </parent>
 
     <dependencies>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>za.co.absa</groupId>
         <artifactId>atum-parent_2.11</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -253,6 +253,7 @@
                 <version>2.4.2</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <autoVersionSubmodules>true</autoVersionSubmodules> <!-- all modules to have the same version -->
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>za.co.absa</groupId>
     <artifactId>atum-parent_2.11</artifactId>
-    <version>3.3.0</version>
+    <version>3.3.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
@@ -69,7 +69,7 @@
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
         <url>${scm.url}</url>
-        <tag>v3.3.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>za.co.absa</groupId>
     <artifactId>atum-parent_2.11</artifactId>
-    <version>3.2.1-SNAPSHOT</version>
+    <version>3.3.0</version>
 
     <packaging>pom</packaging>
 
@@ -69,7 +69,7 @@
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
         <url>${scm.url}</url>
-        <tag>HEAD</tag>
+        <tag>v3.3.0</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
 - release 3.3.0 tag, 3.3.1-SNAPSHOT
 - `maven-release-plugin`'s configuration 
```xml
<autoVersionSubmodules>true</autoVersionSubmodules>
```
has the effect of being only asked for the release & snapshot version once per parent - all submodules then use the same version.