### PR TITLE
Atum model's serialization missing dependencies

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -30,6 +30,16 @@
     <dependencies>
         <dependency>
             <groupId>org.json4s</groupId>
+            <artifactId>json4s-core_${scala.binary.version}</artifactId>
+            <version>${json4s.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json4s</groupId>
+            <artifactId>json4s-jackson_${scala.binary.version}</artifactId>
+            <version>${json4s.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json4s</groupId>
             <artifactId>json4s-native_${scala.binary.version}</artifactId>
             <version>${json4s.version}</version>
             <scope>provided</scope>


### PR DESCRIPTION
A straightforward bugfix of missing dependencies - the missing dependencies have been added to the the `model` submodule
```
"org.json4s" %% "json4s-core" % "3.5.3" % Compile,
"org.json4s" %% "json4s-jackson" % "3.5.3" % Compile,
```

This has the effect of being usable correctly for `model`'s serialization methods without Spark being present (originally it worked with Spark being a co-dependency because it accidentally supplied the needed dependencies).

Tested with a blank project without spark, seems to work 👍 

Thank you, @Zejnilovic, for participating on the-root-cause-discovery.

Closes #63.

## Release notes suggestion:
Bugfix: Atum's model works without extra dependencies or Spark being present.