### PR TITLE
#69 `SparkSessionWrapper` renamed to `AtumSparkSessionWrapper`

### DIFF
--- a/atum-s3-sdk-extension/src/main/scala/za/co/absa/atum/AtumImplicitsSdkS3.scala
+++ b/atum-s3-sdk-extension/src/main/scala/za/co/absa/atum/AtumImplicitsSdkS3.scala
@@ -31,7 +31,7 @@ object AtumImplicitsSdkS3 extends AtumImplicitsBase {
   /**
     * The class contains implicit methods for [[org.apache.spark.sql.SparkSession]].
     */
-  implicit class SparkSessionWrapperSdkS3(sparkSession: SparkSession)(implicit atum: AtumSdkS3) {
+  implicit class AtumSparkSessionWrapperSdkS3(sparkSession: SparkSession)(implicit atum: AtumSdkS3) {
 
     /**
      * Enable S3-based control measurements tracking via SDK S3

--- a/atum/src/main/scala/za/co/absa/atum/AtumImplicits.scala
+++ b/atum/src/main/scala/za/co/absa/atum/AtumImplicits.scala
@@ -59,7 +59,7 @@ trait AtumImplicitsBase {
   /**
     * The class contains implicit methods for [[org.apache.spark.sql.SparkSession]].
     */
-  implicit class SparkSessionWrapper(sparkSession: SparkSession)(implicit atum: Atum) {
+  implicit class AtumSparkSessionWrapper(sparkSession: SparkSession)(implicit atum: Atum) {
 
     /**
       * Enable control measurements tracking on HDFS | S3 (using Hadoop FS API).


### PR DESCRIPTION
There is no logical function change, just making it less likely that you will run into a situation where an implicit `SparkSessionWrapper` already exits and you have to import-rename it just like in #69.

(`AtumSparkSessionWrapperSdkS3` follows suit)