### PR TITLE
79 Add ability to change Software name for checkpoint

### DIFF
--- a/atum/src/main/resources/atum_build.properties
+++ b/atum/src/main/resources/atum_build.properties
@@ -11,4 +11,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+build.software=${project.artifactId}
 build.version=${project.version}

--- a/atum/src/main/scala/za/co/absa/atum/model/CheckpointImplicits.scala
+++ b/atum/src/main/scala/za/co/absa/atum/model/CheckpointImplicits.scala
@@ -21,7 +21,7 @@ object CheckpointImplicits {
 
   implicit class CheckpointExt(checkpoint: Checkpoint) {
     def withBuildProperties: Checkpoint = {
-      checkpoint.copy(software = Some("Atum"), version = Some(BuildProperties.buildVersion))
+      checkpoint.copy(software = Some(BuildProperties.projectName), version = Some(BuildProperties.buildVersion))
     }
   }
 

--- a/atum/src/main/scala/za/co/absa/atum/utils/BuildProperties.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/BuildProperties.scala
@@ -21,10 +21,12 @@ import java.util.Properties
 object BuildProperties {
   private val properties = new Properties()
   private val buildVersionKey = "build.version"
+  private val buildSoftwareKey = "build.software"
 
   /** Returns the version of the build. */
   lazy val buildVersion: String = properties.getProperty(buildVersionKey)
-  val projectName = "Atum"
+  /** Returns the name of the build. */
+  lazy val projectName: String = properties.getProperty(buildSoftwareKey)
 
   loadConfig()
 

--- a/atum/src/test/scala/za/co/absa/atum/BaseTestSuite.scala
+++ b/atum/src/test/scala/za/co/absa/atum/BaseTestSuite.scala
@@ -1,0 +1,47 @@
+package za.co.absa.atum
+
+import za.co.absa.atum.model.{Checkpoint, ControlMeasure}
+
+object BaseTestSuite {
+  val testingVersion = "1.2.3"
+  val testingSoftware = "Atum"
+  val testingDate = "20-02-2020"
+  val testingDateTime1 = "20-02-2020 10:20:30 +0100"
+  val testingDateTime2 = "20-02-2020 10:20:40 +0100"
+
+  /**
+   * Replaces metadata.informationDate, checkpoints.[].{version, processStartTime, processEndTime} with ControlUtilsSpec.testing* values
+   * (and replaces CRLF endings with LF if found, too) in JSON (regarless
+   *
+   * @param actualJson
+   * @return updated json
+   */
+  def stabilizeJsonOutput(actualJson: String): String = {
+    actualJson
+      .replaceFirst("""(?<="informationDate"\s?:\s?")(\d{2}-\d{2}-\d{4})""", testingDate)
+      .replaceAll("""(?<="processStartTime"\s?:\s?")([-+: \d]+)""", testingDateTime1)
+      .replaceAll("""(?<="processEndTime"\s?:\s?")([-+: \d]+)""", testingDateTime2)
+      .replaceAll("""(?<="version"\s?:\s?")([-\d\.A-z]+)""", testingVersion)
+      .replaceAll("""(?<="software"\s?:\s?")([\d\.A-z_]+)""", testingSoftware)
+      .replaceAll("\r\n", "\n") // Windows guard
+  }
+
+  implicit class ControlMeasureStabilizationExt(cm: ControlMeasure) {
+    def replaceInformationDate(newDate: String): ControlMeasure = cm.copy(metadata = cm.metadata.copy(informationDate = newDate))
+
+    def updateCheckpoints(fn: Checkpoint => Checkpoint): ControlMeasure = cm.copy(checkpoints = cm.checkpoints.map(fn))
+
+    def replaceCheckpointsVersion(newVersion: Option[String]): ControlMeasure = cm.updateCheckpoints(_.copy(version = newVersion))
+    def replaceCheckpointsSoftware(newSoftware: Option[String]): ControlMeasure = cm.updateCheckpoints(_.copy(software = newSoftware))
+    def replaceCheckpointsProcessStartTime(newDateTime: String): ControlMeasure = cm.updateCheckpoints(_.copy(processStartTime = newDateTime))
+    def replaceCheckpointsProcessEndTime(newDateTime: String): ControlMeasure = cm.updateCheckpoints(_.copy(processEndTime = newDateTime))
+
+    def stabilizeTestingControlMeasure: ControlMeasure = {
+      cm.replaceInformationDate(testingDate)
+        .replaceCheckpointsVersion(Some(testingVersion))
+        .replaceCheckpointsSoftware(Some(testingSoftware))
+        .replaceCheckpointsProcessStartTime(testingDateTime1)
+        .replaceCheckpointsProcessEndTime(testingDateTime2)
+    }
+  }
+}

--- a/atum/src/test/scala/za/co/absa/atum/BaseTestSuite.scala
+++ b/atum/src/test/scala/za/co/absa/atum/BaseTestSuite.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.atum
 
 import za.co.absa.atum.model.{Checkpoint, ControlMeasure}

--- a/atum/src/test/scala/za/co/absa/atum/ControlInfoToJsonSerializationSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/ControlInfoToJsonSerializationSpec.scala
@@ -80,39 +80,116 @@ class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
     )
   )
   val version = BuildProperties.buildVersion
-  val exampleInputJson: String = "{\"metadata\":{\"sourceApplication\":\"FrontArena\",\"country\":\"ZA\"," +
-    "\"historyType\":\"Snapshot\",\"dataFilename\":\"example.dat\",\"sourceType\":\"\"," +
-    "\"version\":1,\"informationDate\":\"01-01-2017\",\"additionalInfo\":{\"key1\":\"value1\",\"key2\":\"value2\"}}," +
-    "\"checkpoints\":[{\"name\":\"Source\"," +
-    "\"software\":\"Atum\",\"version\":\""+ version + "\"," +
-    "\"processStartTime\":\"01-01-2017 08:00:00\"," +
-    "\"processEndTime\":\"01-01-2017 08:00:00\",\"workflowName\":\"Source\",\"order\":1," +
-    "\"controls\":[{\"controlName\":\"pvControlTotal\",\"controlType\":\"type.aggregatedTotal\"," +
-    "\"controlCol\":\"pv\",\"controlValue\":\"32847283324.324324\"},{\"controlName\":\"recordCount\"," +
-    "\"controlType\":\"type.Count\",\"controlCol\":\"id\",\"controlValue\":243}]},{\"name\":\"Raw\"," +
-    "\"software\":\"Atum\",\"version\":\""+ version + "\"," +
-    "\"processStartTime\":\"01-01-2017 08:00:00\",\"processEndTime\":\"01-01-2017 08:00:00\"," +
-    "\"workflowName\":\"Raw\",\"order\":2,\"controls\":[{\"controlName\":\"pvControlTotal\"," +
-    "\"controlType\":\"type.aggregatedTotal\",\"controlCol\":\"pv\",\"controlValue\":\"32847283324.324324\"}," +
-    "{\"controlName\":\"recordCount\",\"controlType\":\"type.Count\",\"controlCol\":\"id\"," +
-    "\"controlValue\":243}]}]}"
+  val software = BuildProperties.projectName
+  val exampleInputJson: String = s"""{
+     |"metadata":{
+     |"sourceApplication":"FrontArena",
+     |"country":"ZA",
+     |"historyType":"Snapshot",
+     |"dataFilename":"example.dat",
+     |"sourceType":"",
+     |"version":1,
+     |"informationDate":"01-01-2017",
+     |"additionalInfo":{
+     |"key1":"value1",
+     |"key2":"value2"
+     |}
+     |},
+     |"checkpoints":[{
+     |"name":"Source",
+     |"software":"$software",
+     |"version":"$version",
+     |"processStartTime":"01-01-2017 08:00:00",
+     |"processEndTime":"01-01-2017 08:00:00",
+     |"workflowName":"Source",
+     |"order":1,
+     |"controls":[{
+     |"controlName":"pvControlTotal",
+     |"controlType":"type.aggregatedTotal",
+     |"controlCol":"pv",
+     |"controlValue":"32847283324.324324"
+     |},{
+     |"controlName":"recordCount",
+     |"controlType":"type.Count",
+     |"controlCol":"id",
+     |"controlValue":243
+     |}]
+     |},{
+     |"name":"Raw",
+     |"software":"$software",
+     |"version":"$version",
+     |"processStartTime":"01-01-2017 08:00:00",
+     |"processEndTime":"01-01-2017 08:00:00",
+     |"workflowName":"Raw",
+     |"order":2,
+     |"controls":[{
+     |"controlName":"pvControlTotal",
+     |"controlType":"type.aggregatedTotal",
+     |"controlCol":"pv",
+     |"controlValue":"32847283324.324324"
+     |},{
+     |"controlName":"recordCount",
+     |"controlType":"type.Count",
+     |"controlCol":"id",
+     |"controlValue":243
+     |}]
+     |}]
+     |}""".stripMargin.filter(_ >= ' ')
 
-  val exampleOutputJson: String = "{\"metadata\":{\"sourceApplication\":\"FrontArena\",\"country\":\"ZA\"," +
-    "\"historyType\":\"Snapshot\",\"dataFilename\":\"example.dat\",\"sourceType\":\"\"," +
-    "\"version\":1,\"informationDate\":\"01-01-2017\",\"additionalInfo\":{\"key1\":\"value1\",\"key2\":\"value2\"}}," +
-    "\"checkpoints\":[{\"name\":\"Source\"," +
-    "\"software\":\"Atum\",\"version\":\""+ version + "\"," +
-    "\"processStartTime\":\"01-01-2017 08:00:00\"," +
-    "\"processEndTime\":\"01-01-2017 08:00:00\",\"workflowName\":\"Source\",\"order\":1," +
-    "\"controls\":[{\"controlName\":\"pvControlTotal\",\"controlType\":\"aggregatedTotal\"," +
-    "\"controlCol\":\"pv\",\"controlValue\":\"32847283324.324324\"},{\"controlName\":\"recordCount\"," +
-    "\"controlType\":\"count\",\"controlCol\":\"id\",\"controlValue\":\"243\"}]},{\"name\":\"Raw\"," +
-    "\"software\":\"Atum\",\"version\":\""+ version + "\"," +
-    "\"processStartTime\":\"01-01-2017 08:00:00\",\"processEndTime\":\"01-01-2017 08:00:00\"," +
-    "\"workflowName\":\"Raw\",\"order\":2,\"controls\":[{\"controlName\":\"pvControlTotal\"," +
-    "\"controlType\":\"aggregatedTotal\",\"controlCol\":\"pv\",\"controlValue\":\"32847283324.324324\"}," +
-    "{\"controlName\":\"recordCount\",\"controlType\":\"count\",\"controlCol\":\"id\"," +
-    "\"controlValue\":\"243\"}]}]}"
+  val exampleOutputJson: String = s"""{
+     |"metadata":{
+     |"sourceApplication":"FrontArena",
+     |"country":"ZA",
+     |"historyType":"Snapshot",
+     |"dataFilename":"example.dat",
+     |"sourceType":"",
+     |"version":1,
+     |"informationDate":"01-01-2017",
+     |"additionalInfo":{
+     |"key1":"value1",
+     |"key2":"value2"
+     |}
+     |},
+     |"checkpoints":[{
+     |"name":"Source",
+     |"software":"$software",
+     |"version":"$version",
+     |"processStartTime":"01-01-2017 08:00:00",
+     |"processEndTime":"01-01-2017 08:00:00",
+     |"workflowName":"Source",
+     |"order":1,
+     |"controls":[{
+     |"controlName":"pvControlTotal",
+     |"controlType":"aggregatedTotal",
+     |"controlCol":"pv",
+     |"controlValue":"32847283324.324324"
+     |},{
+     |"controlName":"recordCount",
+     |"controlType":"count",
+     |"controlCol":"id",
+     |"controlValue":"243"
+     |}]
+     |},{
+     |"name":"Raw",
+     |"software":"$software",
+     |"version":"$version",
+     |"processStartTime":"01-01-2017 08:00:00",
+     |"processEndTime":"01-01-2017 08:00:00",
+     |"workflowName":"Raw",
+     |"order":2,
+     |"controls":[{
+     |"controlName":"pvControlTotal",
+     |"controlType":"aggregatedTotal",
+     |"controlCol":"pv",
+     |"controlValue":"32847283324.324324"
+     |},{
+     |"controlName":"recordCount",
+     |"controlType":"count",
+     |"controlCol":"id",
+     |"controlValue":"243"
+     |}]
+     |}]
+     |}""".stripMargin.filter(_ >= ' ')
 
   "toJson" should "serialize a ControlInfo object" in
   {

--- a/atum/src/test/scala/za/co/absa/atum/ControlInfoToJsonSerializationSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/ControlInfoToJsonSerializationSpec.scala
@@ -26,7 +26,10 @@ import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtils
   * Unit tests for ControlInfo object serialization
   */
 class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
-  val exampleCtrlInfo = ControlMeasure(
+  private val version = BuildProperties.buildVersion
+  private val software = BuildProperties.projectName
+
+  private val exampleCtrlInfo = ControlMeasure(
     metadata = ControlMeasureMetadata(
       sourceApplication = "FrontArena",
       country = "ZA",
@@ -79,9 +82,8 @@ class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
     ).withBuildProperties
     )
   )
-  val version = BuildProperties.buildVersion
-  val software = BuildProperties.projectName
-  val exampleInputJson: String = s"""{
+
+  private val exampleInputJson: String = s"""{
      |"metadata":{
      |"sourceApplication":"FrontArena",
      |"country":"ZA",
@@ -136,7 +138,7 @@ class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
      |}]
      |}""".stripMargin.filter(_ >= ' ')
 
-  val exampleOutputJson: String = s"""{
+  private val exampleOutputJson: String = s"""{
      |"metadata":{
      |"sourceApplication":"FrontArena",
      |"country":"ZA",

--- a/atum/src/test/scala/za/co/absa/atum/ControlMeasureBaseTestSuite.scala
+++ b/atum/src/test/scala/za/co/absa/atum/ControlMeasureBaseTestSuite.scala
@@ -17,7 +17,7 @@ package za.co.absa.atum
 
 import za.co.absa.atum.model.{Checkpoint, ControlMeasure}
 
-object BaseTestSuite {
+trait ControlMeasureBaseTestSuite {
   val testingVersion = "1.2.3"
   val testingSoftware = "Atum"
   val testingDate = "20-02-2020"
@@ -26,7 +26,7 @@ object BaseTestSuite {
 
   /**
    * Replaces metadata.informationDate, checkpoints.[].{version, processStartTime, processEndTime} with ControlUtilsSpec.testing* values
-   * (and replaces CRLF endings with LF if found, too) in JSON (regarless
+   * (and replaces CRLF endings with LF if found, too) in JSON
    *
    * @param actualJson
    * @return updated json

--- a/atum/src/test/scala/za/co/absa/atum/utils/BuildPropertiesSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/BuildPropertiesSpec.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package za.co.absa.atum.utils
 
 import org.scalatest.flatspec.AnyFlatSpec

--- a/atum/src/test/scala/za/co/absa/atum/utils/BuildPropertiesSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/BuildPropertiesSpec.scala
@@ -1,0 +1,24 @@
+package za.co.absa.atum.utils
+
+import org.scalatest.flatspec.AnyFlatSpec
+import za.co.absa.commons.version.Version
+
+import scala.util.{Failure, Success, Try}
+
+class BuildPropertiesSpec extends AnyFlatSpec  {
+  private val version = BuildProperties.buildVersion
+  private val name = BuildProperties.projectName
+
+  "Project version" should "be parsable by the semVer" in {
+    Try {
+      Version.asSemVer(version)
+    } match {
+      case Success(_) => succeed
+      case Failure(exception) => fail(exception.getMessage, exception.getCause)
+    }
+  }
+
+  "Project Name" should "start with atum and scala version" in {
+    assert(name.matches("""^atum_(2\.11|2\.12)$"""))
+  }
+}

--- a/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilderTest.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilderTest.scala
@@ -18,13 +18,14 @@ package za.co.absa.atum.utils.controlmeasure
 import org.apache.spark.sql.DataFrame
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import za.co.absa.atum.BaseTestSuite
 import za.co.absa.atum.model._
 import za.co.absa.atum.utils.SparkTestBase
-import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtilsSpec._
 
 class ControlMeasureBuilderTest extends AnyFlatSpec with SparkTestBase with Matchers {
 
   import spark.implicits._
+  import za.co.absa.atum.BaseTestSuite._
 
   val colNames = Seq("col1", "col2")
   val testingDf: DataFrame = Seq(
@@ -36,12 +37,19 @@ class ControlMeasureBuilderTest extends AnyFlatSpec with SparkTestBase with Matc
     val defaultCm = ControlMeasureBuilder.forDF(testingDf).build
 
     val expectedDefaultControlMeasure: ControlMeasure = ControlMeasure(
-      ControlMeasureMetadata("", "ZA", "Snapshot", "", "Source", 1, testingDate, Map()),
+      ControlMeasureMetadata("", "ZA", "Snapshot", "", "Source", 1, BaseTestSuite.testingDate, Map()),
       None,
       List(
-        Checkpoint("Source", Some(testingSoftware), Some(testingVersion), testingDateTime1, testingDateTime2, "Source", 1, List(
-          Measurement("recordCount", "count", "*", "2")
-        ))
+        Checkpoint(
+          "Source",
+          Some(BaseTestSuite.testingSoftware),
+          Some(BaseTestSuite.testingVersion),
+          BaseTestSuite.testingDateTime1,
+          BaseTestSuite.testingDateTime2,
+          "Source",
+          1,
+          List(Measurement("recordCount", "count", "*", "2"))
+        )
       )
     )
 
@@ -62,13 +70,23 @@ class ControlMeasureBuilderTest extends AnyFlatSpec with SparkTestBase with Matc
       .build
 
     val expectedCustomControlMeasure: ControlMeasure = ControlMeasure(
-      ControlMeasureMetadata("SourceApp1", "CZ", "HistoryType1", "input/path1", "SourceType1", 1, testingDate, Map()),
+      ControlMeasureMetadata("SourceApp1", "CZ", "HistoryType1", "input/path1", "SourceType1", 1, BaseTestSuite.testingDate, Map()),
       None,
       List(
-        Checkpoint("InitCheckpoint1", Some(testingSoftware), Some(testingVersion), testingDateTime1, testingDateTime2, "Workflow1", 1, List(
-          Measurement("recordCount", "count", "*", "2"),
-          Measurement("col1ControlTotal", "hashCrc32", "col1", "4497723351"),
-          Measurement("col2ControlTotal", "absAggregatedTotal", "col2", "23")))
+        Checkpoint(
+          "InitCheckpoint1",
+          Some(BaseTestSuite.testingSoftware),
+          Some(BaseTestSuite.testingVersion),
+          BaseTestSuite.testingDateTime1,
+          BaseTestSuite.testingDateTime2,
+          "Workflow1",
+          1,
+          List(
+            Measurement("recordCount", "count", "*", "2"),
+            Measurement("col1ControlTotal", "hashCrc32", "col1", "4497723351"),
+            Measurement("col2ControlTotal", "absAggregatedTotal", "col2", "23")
+          )
+        )
       )
     )
 

--- a/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilderTest.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilderTest.scala
@@ -39,7 +39,7 @@ class ControlMeasureBuilderTest extends AnyFlatSpec with SparkTestBase with Matc
       ControlMeasureMetadata("", "ZA", "Snapshot", "", "Source", 1, testingDate, Map()),
       None,
       List(
-        Checkpoint("Source", Some("Atum"), Some(testingVersion), testingDateTime1, testingDateTime2, "Source", 1, List(
+        Checkpoint("Source", Some(testingSoftware), Some(testingVersion), testingDateTime1, testingDateTime2, "Source", 1, List(
           Measurement("recordCount", "count", "*", "2")
         ))
       )
@@ -65,7 +65,7 @@ class ControlMeasureBuilderTest extends AnyFlatSpec with SparkTestBase with Matc
       ControlMeasureMetadata("SourceApp1", "CZ", "HistoryType1", "input/path1", "SourceType1", 1, testingDate, Map()),
       None,
       List(
-        Checkpoint("InitCheckpoint1", Some("Atum"), Some(testingVersion), testingDateTime1, testingDateTime2, "Workflow1", 1, List(
+        Checkpoint("InitCheckpoint1", Some(testingSoftware), Some(testingVersion), testingDateTime1, testingDateTime2, "Workflow1", 1, List(
           Measurement("recordCount", "count", "*", "2"),
           Measurement("col1ControlTotal", "hashCrc32", "col1", "4497723351"),
           Measurement("col2ControlTotal", "absAggregatedTotal", "col2", "23")))

--- a/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtilsSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtilsSpec.scala
@@ -25,6 +25,7 @@ import za.co.absa.atum.utils.{HdfsFileUtils, SparkTestBase}
 
 object ControlMeasureUtilsSpec {
   val testingVersion = "1.2.3"
+  val testingSoftware = "Atum"
   val testingDate = "20-02-2020"
   val testingDateTime1 = "20-02-2020 10:20:30 +0100"
   val testingDateTime2 = "20-02-2020 10:20:40 +0100"
@@ -42,6 +43,7 @@ object ControlMeasureUtilsSpec {
       .replaceAll("""(?<="processStartTime"\s?:\s?")([-+: \d]+)""", testingDateTime1)
       .replaceAll("""(?<="processEndTime"\s?:\s?")([-+: \d]+)""", testingDateTime2)
       .replaceAll("""(?<="version"\s?:\s?")([-\d\.A-z]+)""", testingVersion)
+      .replaceAll("""(?<="software"\s?:\s?")([\d\.A-z_]+)""", testingSoftware)
       .replaceAll("\r\n", "\n") // Windows guard
   }
 
@@ -51,12 +53,14 @@ object ControlMeasureUtilsSpec {
     def updateCheckpoints(fn: Checkpoint => Checkpoint): ControlMeasure = cm.copy(checkpoints = cm.checkpoints.map(fn))
 
     def replaceCheckpointsVersion(newVersion: Option[String]): ControlMeasure = cm.updateCheckpoints(_.copy(version = newVersion))
+    def replaceCheckpointsSoftware(newSoftware: Option[String]): ControlMeasure = cm.updateCheckpoints(_.copy(software = newSoftware))
     def replaceCheckpointsProcessStartTime(newDateTime: String): ControlMeasure = cm.updateCheckpoints(_.copy(processStartTime = newDateTime))
     def replaceCheckpointsProcessEndTime(newDateTime: String): ControlMeasure = cm.updateCheckpoints(_.copy(processEndTime = newDateTime))
 
     def stabilizeTestingControlMeasure: ControlMeasure = {
       cm.replaceInformationDate(testingDate)
         .replaceCheckpointsVersion(Some(testingVersion))
+        .replaceCheckpointsSoftware(Some(testingSoftware))
         .replaceCheckpointsProcessStartTime(testingDateTime1)
         .replaceCheckpointsProcessEndTime(testingDateTime2)
     }

--- a/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtilsSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtilsSpec.scala
@@ -21,9 +21,9 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtils.JsonType
 import za.co.absa.atum.utils.{HdfsFileUtils, SparkTestBase}
-import za.co.absa.atum.BaseTestSuite
+import za.co.absa.atum.ControlMeasureBaseTestSuite
 
-class ControlMeasureUtilsSpec extends AnyFlatSpec with Matchers with SparkTestBase {
+class ControlMeasureUtilsSpec extends AnyFlatSpec with ControlMeasureBaseTestSuite with Matchers with SparkTestBase {
 
   import spark.implicits._
 
@@ -35,9 +35,9 @@ class ControlMeasureUtilsSpec extends AnyFlatSpec with Matchers with SparkTestBa
 
   private val expectedJsonForSingleIntColumn =
     s"""{"metadata":{"sourceApplication":"Test","country":"ZA","historyType":"Snapshot","dataFilename":"_testOutput/data",
-       |"sourceType":"Source","version":1,"informationDate":"${BaseTestSuite.testingDate}","additionalInfo":{}},
-       |"checkpoints":[{"name":"Source","software":"${BaseTestSuite.testingSoftware}","version":"${BaseTestSuite.testingVersion}",
-       |"processStartTime":"${BaseTestSuite.testingDateTime1}","processEndTime":"${BaseTestSuite.testingDateTime2}",
+       |"sourceType":"Source","version":1,"informationDate":"$testingDate","additionalInfo":{}},
+       |"checkpoints":[{"name":"Source","software":"$testingSoftware","version":"$testingVersion",
+       |"processStartTime":"$testingDateTime1","processEndTime":"$testingDateTime2",
        |"workflowName":"Source","order":1,"controls":[{"controlName":"recordCount","controlType":"count","controlCol":"*",
        |"controlValue":"4"},{"controlName":"valueControlTotal","controlType":"absAggregatedTotal","controlCol":"value",
        |"controlValue":"21099"}]}]}""".stripMargin.replaceAll("\n", "")
@@ -51,15 +51,15 @@ class ControlMeasureUtilsSpec extends AnyFlatSpec with Matchers with SparkTestBa
        |    "dataFilename" : "_testOutput/data",
        |    "sourceType" : "Source",
        |    "version" : 1,
-       |    "informationDate" : "${BaseTestSuite.testingDate}",
+       |    "informationDate" : "$testingDate",
        |    "additionalInfo" : { }
        |  },
        |  "checkpoints" : [ {
        |    "name" : "Source",
-       |    "software" : "${BaseTestSuite.testingSoftware}",
-       |    "version" : "${BaseTestSuite.testingVersion}",
-       |    "processStartTime" : "${BaseTestSuite.testingDateTime1}",
-       |    "processEndTime" : "${BaseTestSuite.testingDateTime2}",
+       |    "software" : "$testingSoftware",
+       |    "version" : "$testingVersion",
+       |    "processStartTime" : "$testingDateTime1",
+       |    "processEndTime" : "$testingDateTime2",
        |    "workflowName" : "Source",
        |    "order" : 1,
        |    "controls" : [ {
@@ -89,14 +89,14 @@ class ControlMeasureUtilsSpec extends AnyFlatSpec with Matchers with SparkTestBa
       val actual = ControlMeasureUtils.createInfoFile(singleIntColumnDF, "Test", "_testOutput/data",
         writeToHDFS = true, prettyJSON = isJsonPretty, aggregateColumns = Seq("value"))
       // replace non-stable fields (date/time, version) using rx lookbehind
-      val actualStabilized = BaseTestSuite.stabilizeJsonOutput(actual)
+      val actualStabilized = stabilizeJsonOutput(actual)
 
       // testing the generated jsons
       assert(actualStabilized == expectedMeasureJson, "Generated json does not match")
 
       // check the what's actually written to "HDFS"
       val actual2 = HdfsFileUtils.readHdfsFileToString(new Path("_testOutput/data/_INFO"))
-      assert(BaseTestSuite.stabilizeJsonOutput(actual2) == expectedMeasureJson, "json written to _testOutput/data/_INFO")
+      assert(stabilizeJsonOutput(actual2) == expectedMeasureJson, "json written to _testOutput/data/_INFO")
 
       hdfs.deleteOnExit(new Path("_testOutput")) // eventual cleanup
     }
@@ -121,7 +121,7 @@ class ControlMeasureUtilsSpec extends AnyFlatSpec with Matchers with SparkTestBa
 
       // check the what's actually written to "HDFS"
       val actual = HdfsFileUtils.readHdfsFileToString(new Path("_testOutput/data/_INFO"))
-      assert(BaseTestSuite.stabilizeJsonOutput(actual) == expectedMeasureJson, "json written to _testOutput/data/_INFO")
+      assert(stabilizeJsonOutput(actual) == expectedMeasureJson, "json written to _testOutput/data/_INFO")
 
       hdfs.deleteOnExit(new Path("_testOutput")) // eventual cleanup
     }

--- a/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
+++ b/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
@@ -16,27 +16,25 @@
 package za.co.absa.atum
 
 import java.nio.file.{Files, Paths}
+
 import org.apache.hadoop.fs.FileSystem
 import org.apache.log4j.LogManager
-import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
-import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.flatspec.{AnyFlatSpec, AsyncFlatSpec}
 import org.scalatest.matchers.should.Matchers
+import org.specs2.matcher.Matchers.concurrentExecutionContext
 import za.co.absa.atum.model.{Checkpoint, Measurement}
 import za.co.absa.atum.persistence.ControlMeasuresParser
 import za.co.absa.atum.utils.SparkTestBase
 import za.co.absa.atum.AtumImplicits._
 
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.{Await, Future}
 
-
-class HdfsInfoIntegrationSuite extends AnyFlatSpec
-  with SparkTestBase
-  with Matchers
-  with BeforeAndAfterAll
-  with Eventually {
+class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Matchers with BeforeAndAfterAll with Eventually {
 
   private val log = LogManager.getLogger(this.getClass)
   val tempDir: String = LocalFsTestUtils.createLocalTemporaryDirectory("hdfsTestOutput")
@@ -86,27 +84,21 @@ class HdfsInfoIntegrationSuite extends AnyFlatSpec
 
         spark.disableControlMeasuresTracking()
 
-        spark.sparkContext.addSparkListener(new SparkListener() {
-          override def onTaskEnd(taskEnd: SparkListenerTaskEnd) {
-            synchronized {
-              expectedPaths.foreach { expectedPath =>
-                log.info(s"Checking $expectedPath to contain expected values")
+        expectedPaths.foreach { expectedPath =>
+          log.info(s"Checking $expectedPath to contain expected values")
 
-                val infoControlMeasures =  eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
-                  val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
-                  ControlMeasuresParser.fromJson(infoContentJson)
-                }
-
-                infoControlMeasures.checkpoints.map(_.name) shouldBe Seq("Source", "Raw", "Checkpoint0", "Checkpoint1")
-                val checkpoint0 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint0" => c }.get
-                checkpoint0.controls should contain(Measurement("recordCount", "count", "*", "5000"))
-
-                val checkpoint1 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint1" => c }.get
-                checkpoint1.controls should contain(Measurement("recordCount", "count", "*", "4964"))
-              }
-            }
+          val infoControlMeasures =  eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
+            val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
+            ControlMeasuresParser.fromJson(infoContentJson)
           }
-        })
+
+          infoControlMeasures.checkpoints.map(_.name) shouldBe Seq("Source", "Raw", "Checkpoint0", "Checkpoint1")
+          val checkpoint0 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint0" => c }.get
+          checkpoint0.controls should contain(Measurement("recordCount", "count", "*", "5000"))
+
+          val checkpoint1 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint1" => c }.get
+          checkpoint1.controls should contain(Measurement("recordCount", "count", "*", "4964"))
+        }
       }
     }
   }

--- a/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
+++ b/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
@@ -88,6 +88,7 @@ class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Match
           log.info(s"Checking $expectedPath to contain expected values")
 
           val infoControlMeasures =  eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
+            log.info(s"Reading $expectedPath")
             val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
             ControlMeasuresParser.fromJson(infoContentJson)
           }


### PR DESCRIPTION
This works by adding your own `atum_build.properties` to your library generating checkpoints and in merge strategy overwriting it. 

For sbt:

```scala
val mergeStrategy = assemblyMergeStrategy in assembly := {
  case "atum_build.properties" => MergeStrategy.last
}
```

**Idea/Question:** Should I add an implementation similar to typesafe config? Like `atum_build.reference` (in Atum) and `atum_build.properties` in the code that uses Atum? Maybe it would be easier to grasp?

Fixes #79 