### PR TITLE
#83 jackson serialization support 

### DIFF
--- a/model/src/main/scala/za/co/absa/atum/model/RunStatus.scala
+++ b/model/src/main/scala/za/co/absa/atum/model/RunStatus.scala
@@ -15,10 +15,15 @@
 
 package za.co.absa.atum.model
 
+import com.fasterxml.jackson.core.`type`.TypeReference
+import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
 import za.co.absa.atum.model.RunState.RunState
+
+class RunStateType extends TypeReference[RunState.type]
 
 case class RunStatus
 (
+  @JsonScalaEnumeration(classOf[RunStateType])
   status: RunState,
   error: Option[RunError]
 )

--- a/model/src/test/scala/za/co/absa/atum/util/JacksonJsonSerializer.scala
+++ b/model/src/test/scala/za/co/absa/atum/util/JacksonJsonSerializer.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018-2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.util
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+
+import scala.reflect.ClassTag
+import scala.util.Try
+
+/**
+ * Sample serializer that is expected to be used for Atum's model externally, e.g. in Enceladus
+ */
+object JacksonJsonSerializer {
+
+  val objectMapper: ObjectMapper = new ObjectMapper()
+    .registerModule(DefaultScalaModule)
+    .setSerializationInclusion(Include.NON_EMPTY) // e.g. null-values fields omitted
+
+
+  def fromJson[T](json: String)
+                 (implicit ct: ClassTag[T]): T = {
+    val clazz = ct.runtimeClass.asInstanceOf[Class[T]]
+    if (clazz == classOf[String]) {
+      json.asInstanceOf[T]
+    } else {
+      objectMapper.readValue(json, clazz)
+    }
+  }
+
+  def toJson[T](entity: T): String = {
+    entity match {
+      case str: String =>
+        if (isValidJson(str)) str else objectMapper.writeValueAsString(entity)
+      case _ =>
+        objectMapper.writeValueAsString(entity)
+    }
+  }
+
+  def isValidJson[T](str: T with String): Boolean = {
+    Try(objectMapper.readTree(str)).isSuccess
+  }
+
+}

--- a/model/src/test/scala/za/co/absa/atum/util/SerializationUtilsJsonSpec.scala
+++ b/model/src/test/scala/za/co/absa/atum/util/SerializationUtilsJsonSpec.scala
@@ -21,7 +21,7 @@ import za.co.absa.atum.model.{Checkpoint, ControlMeasure, ControlMeasureMetadata
 import za.co.absa.atum.utils.SerializationUtils
 
 /**
- * Unit tests for ControlMeasure SerializationUtils-based object serialization
+ * Unit tests for ControlMeasure and RunStatus SerializationUtils-based object serialization
  */
 class SerializationUtilsJsonSpec extends AnyFlatSpec with Matchers {
 
@@ -134,6 +134,15 @@ class SerializationUtilsJsonSpec extends AnyFlatSpec with Matchers {
 
   it should "serialize via asJsonPretty and deserialize back" in {
     SerializationUtils.fromJson[Seq[RunStatus]](SerializationUtils.asJsonPretty(runStatuses)) shouldEqual runStatuses
+  }
+
+  // jackson serialization support (notice the `runStatusesJson` being reused):
+  it should "serialize via Jackson's toJson" in {
+    JacksonJsonSerializer.toJson(runStatuses) shouldBe runStatusesJson
+  }
+
+  it should "deserialize via Jackson's fromJson" in {
+    JacksonJsonSerializer.fromJson[Array[RunStatus]](runStatusesJson) shouldBe runStatuses // Array to overcome runtime erasure
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
 
         <!-- Frameworks and libraries -->
         <json4s.version>3.5.3</json4s.version> <!-- This version is set to be compatible with Spark 2.4.5 -->
+        <jackson.version>2.10.4</jackson.version>
         <scalatest.maven.version>2.0.2</scalatest.maven.version>
         <scalatest.version>3.2.2</scalatest.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -149,6 +150,16 @@
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>com.fasterxml.jackson.core</artifactId>
+                    <groupId>jackson-databind</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>com.fasterxml.jackson.module</artifactId>
+                    <groupId>jackson-module-scala_${scala.binary.version}</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -163,6 +174,18 @@
             <artifactId>json4s-ext_${scala.binary.version}</artifactId>
             <version>${json4s.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
 
         <!-- scalatest -->
         <dependency>


### PR DESCRIPTION
Jackson serialization support was added for `RunStatus` (contains a field of `RunState` enum type)
 - unit test cases for this has been added

 - discussion point - **Breaking-compatibility-wise, should this be introduced as part of Atum 4?**

# Test-run
 - Manually tested in Enceladus (2.x @ Scala 2.11), Enceladus (3.x @ Scala 2.12) using a local snapshot dependency, namely in [commit 7f2d6e55324514b7f4093f260d20091559ab4f09 (branch `develop-ver-3.0`)](https://github.com/AbsaOSS/enceladus/blob/7f2d6e55324514b7f4093f260d20091559ab4f09/dao/src/test/scala/za/co/absa/enceladus/dao/rest/JsonSerializerSuite.scala#L343). 
   - originally, the test passes with this JSON value:
   ```json
    "runStatus": {
      "status": {
        "enumClass": "za.co.absa.atum.model.RunState",
        "value": "allSucceeded"
      },
      "error": null
    },
   ```
   - after using this Atum snapshot, the test passes with:
   ```json
     "runStatus": {
       "status": "allSucceeded",
       "error": null
     },
   ```

Closes #83.
