### PR TITLE
85 Refactor of BuildProperties and withBuiltProperties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ name: Automatic build
 
 on:
   pull_request:
-    branches: [ master , 'releases/**' ]
+    branches: [ master , 'release/**' ]
     types: [assigned, opened, synchronize, reopened, labeled]
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ name: Automatic build
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master , 'releases/**' ]
     types: [assigned, opened, synchronize, reopened, labeled]
 
 jobs:

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -17,9 +17,9 @@ name: License Check
 
 on:
   push:
-    branches: [ master, 'releases/**' ]
+    branches: [ master, 'release/**' ]
   pull_request:
-    branches: [ master, 'releases/**' ]
+    branches: [ master, 'release/**' ]
 
 jobs:
   license-test:

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -17,9 +17,9 @@ name: License Check
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master, 'releases/**' ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ master, 'releases/**' ]
 
 jobs:
   license-test:

--- a/atum/src/main/scala/za/co/absa/atum/AtumImplicits.scala
+++ b/atum/src/main/scala/za/co/absa/atum/AtumImplicits.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.{Dataset, Row, SparkSession}
 import za.co.absa.atum.core.{Atum, Constants}
 import za.co.absa.atum.persistence._
 import za.co.absa.atum.persistence.hdfs.{ControlMeasuresHdfsLoaderJsonFile, ControlMeasuresHdfsStorerJsonFile}
-import za.co.absa.atum.utils.InfoFile
+import za.co.absa.atum.utils.{BuildProperties, DefaultBuildProperties, InfoFile}
 
 import scala.language.implicitConversions
 
@@ -94,13 +94,30 @@ trait AtumImplicitsBase {
      */
     def enableControlMeasuresTracking(sourceInfoFilePath: Option[String],
                                       destinationInfoFilePath: Option[String]): SparkSession = {
+      enableControlMeasuresTracking(sourceInfoFilePath, destinationInfoFilePath, DefaultBuildProperties)
+    }
+
+    /**
+     * Enable control measurements tracking on HDFS | S3 (using Hadoop FS API).
+     * Input and output info file names will be inferred automatically based on data source and destination paths if not provided
+     *
+     * Example info file path name: "data/input/wikidata.csv.info" or "s3://bucket1/folder1/wikidata.csv.info"
+     *
+     * @param sourceInfoFilePath      Pathname to a json-formatted info file containing control measurements
+     * @param destinationInfoFilePath Pathname to save the control measurement results to
+     */
+    def enableControlMeasuresTracking(sourceInfoFilePath: Option[String],
+                                      destinationInfoFilePath: Option[String],
+                                      buildProperties: BuildProperties): SparkSession = {
       implicit val hadoopConfiguration: Configuration = sparkSession.sparkContext.hadoopConfiguration
 
       val loader: Option[ControlMeasuresLoader] = sourceInfoFilePath.map(InfoFile(_).toDefaultControlInfoLoader)
       val storer: Option[ControlMeasuresStorer] = destinationInfoFilePath.map(InfoFile(_).toDefaultControlInfoStorer)
 
-      enableControlMeasuresTrackingDirectly(loader, storer)
+      enableControlMeasuresTrackingDirectly(loader, storer, buildProperties)
     }
+
+
 
     /**
      * Enable control measurements tracking with loader and/or storer directly.
@@ -112,7 +129,8 @@ trait AtumImplicitsBase {
      *
      */
     private[atum] def enableControlMeasuresTrackingDirectly(loader: Option[ControlMeasuresLoader],
-                                                            storer: Option[ControlMeasuresStorer]): SparkSession =
+                                                            storer: Option[ControlMeasuresStorer],
+                                                            buildProperties: BuildProperties = DefaultBuildProperties): SparkSession =
       sparkSession.synchronized {
         atum.init(sparkSession)
 
@@ -123,6 +141,8 @@ trait AtumImplicitsBase {
         if (storer.nonEmpty) {
           atum.setStorer(storer.get)
         }
+
+        atum.setBuildProperties(buildProperties)
 
         sparkSession
       }

--- a/atum/src/main/scala/za/co/absa/atum/AtumImplicits.scala
+++ b/atum/src/main/scala/za/co/absa/atum/AtumImplicits.scala
@@ -105,6 +105,7 @@ trait AtumImplicitsBase {
      *
      * @param sourceInfoFilePath      Pathname to a json-formatted info file containing control measurements
      * @param destinationInfoFilePath Pathname to save the control measurement results to
+     * @param buildProperties         Build properties to be used while creating _INFO and adding checkpoints
      */
     def enableControlMeasuresTracking(sourceInfoFilePath: Option[String],
                                       destinationInfoFilePath: Option[String],

--- a/atum/src/main/scala/za/co/absa/atum/core/Accumulator.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/Accumulator.scala
@@ -20,6 +20,7 @@ import za.co.absa.atum.model
 import za.co.absa.atum.persistence.{ControlMeasuresLoader, ControlMeasuresParser, ControlMeasuresStorer}
 import za.co.absa.atum.model._
 import za.co.absa.atum.model.CheckpointImplicits.CheckpointExt
+import za.co.absa.atum.utils.BuildProperties
 import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtils
 
 import scala.util.control.NonFatal
@@ -30,6 +31,7 @@ import scala.util.control.NonFatal
 class Accumulator() {
   private var controlMeasure: ControlMeasure = _
   private var storer: ControlMeasuresStorer = _
+  private var buildProperties: BuildProperties = _
   private var lastProcessingDate: String = ControlMeasureUtils.getTimestampAsString
 
   def isControlMeasuresLoaded: Boolean = controlMeasure != null
@@ -49,6 +51,10 @@ class Accumulator() {
   /** Sets a persistor object for saving control checkpoints. */
   def setStorer(storerIn: ControlMeasuresStorer): Unit = {
     storer = storerIn
+  }
+
+  def setBuildProperties(buildPropertiesIn: BuildProperties): Unit = {
+    buildProperties = buildPropertiesIn
   }
 
   /** Gets information about the storer. */
@@ -124,7 +130,7 @@ class Accumulator() {
       workflowName = workflowName,
       order = order,
       controls = controls.toList)
-      .withBuildProperties
+      .withSoftware(buildProperties.projectName, buildProperties.buildVersion)
     lastProcessingDate = timestampStr
     controlMeasure = ControlMeasure(controlMeasure.metadata, controlMeasure.runUniqueId, checkpoint :: controlMeasure.checkpoints)
     checkpoint

--- a/atum/src/main/scala/za/co/absa/atum/core/Atum.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/Atum.scala
@@ -24,6 +24,7 @@ import org.apache.spark.storage.StorageLevel
 import za.co.absa.atum.model.ControlMeasure
 import za.co.absa.atum.persistence.{ControlMeasuresLoader, ControlMeasuresStorer}
 import za.co.absa.atum.plugins.EventListener
+import za.co.absa.atum.utils.BuildProperties
 
 /**
   * The object coordinates access to control measurements state
@@ -190,6 +191,11 @@ trait Atum {
   private[atum] def setStorer(storer: ControlMeasuresStorer): Unit = {
     preventNotInitialized()
     controlFrameworkState.setStorer(storer)
+  }
+
+  private[atum] def setBuildProperties(buildProperties: BuildProperties): Unit = {
+    preventNotInitialized()
+    controlFrameworkState.setBuildProperties(buildProperties)
   }
 
   private[atum] def setControlMeasuresInputFileName(fileName: String): Unit = {

--- a/atum/src/main/scala/za/co/absa/atum/core/ControlFrameworkState.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/ControlFrameworkState.scala
@@ -25,6 +25,7 @@ import za.co.absa.atum.model.{RunError, RunState, _}
 import za.co.absa.atum.persistence.hdfs.ControlMeasuresHdfsStorerJsonFile
 import za.co.absa.atum.persistence.{ControlMeasuresLoader, ControlMeasuresStorer}
 import za.co.absa.atum.plugins.EventListener
+import za.co.absa.atum.utils.BuildProperties
 import za.co.absa.atum.utils.ExecutionPlanUtils.inferInputInfoFilePath
 
 import scala.util.control.NonFatal
@@ -50,6 +51,10 @@ class ControlFrameworkState(sparkSession: SparkSession) {
 
   private[atum] def setStorer(storer: ControlMeasuresStorer): Unit = {
     accumulator.setStorer(storer)
+  }
+
+  private[atum] def setBuildProperties(buildProperties: BuildProperties): Unit = {
+    accumulator.setBuildProperties(buildProperties)
   }
 
   private[atum] def setAllowUnpersistOldDatasets(allowUnpersist: Boolean): Unit = {

--- a/atum/src/main/scala/za/co/absa/atum/model/CheckpointImplicits.scala
+++ b/atum/src/main/scala/za/co/absa/atum/model/CheckpointImplicits.scala
@@ -15,13 +15,14 @@
 
 package za.co.absa.atum.model
 
-import za.co.absa.atum.utils.BuildProperties
+import za.co.absa.atum.utils.DefaultBuildProperties
 
 object CheckpointImplicits {
 
   implicit class CheckpointExt(checkpoint: Checkpoint) {
-    def withBuildProperties: Checkpoint = {
-      checkpoint.copy(software = Some(BuildProperties.projectName), version = Some(BuildProperties.buildVersion))
+    def withSoftware(name: String = DefaultBuildProperties.projectName,
+                     version: String = DefaultBuildProperties.buildVersion): Checkpoint = {
+      checkpoint.copy(software = Some(name), version = Some(version))
     }
   }
 

--- a/atum/src/main/scala/za/co/absa/atum/utils/BuildProperties.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/BuildProperties.scala
@@ -16,27 +16,6 @@
 
 package za.co.absa.atum.utils
 
-import java.util.Properties
-
-object DefaultBuildProperties extends BuildProperties {
-  private val properties = new Properties()
-  private val buildVersionKey = "build.version"
-  private val buildSoftwareKey = "build.software"
-
-  /** Returns the version of the build. */
-  lazy val buildVersion: String = properties.getProperty(buildVersionKey)
-  /** Returns the name of the build. */
-  lazy val projectName: String = properties.getProperty(buildSoftwareKey)
-
-  loadConfig()
-
-  private def loadConfig(): Unit = {
-    val is = getClass.getResourceAsStream("/atum_build.properties")
-    try properties.load(is)
-    finally if (is != null) is.close()
-  }
-}
-
 trait BuildProperties {
   val buildVersion: String
   val projectName: String

--- a/atum/src/main/scala/za/co/absa/atum/utils/BuildProperties.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/BuildProperties.scala
@@ -18,7 +18,7 @@ package za.co.absa.atum.utils
 
 import java.util.Properties
 
-object BuildProperties {
+object DefaultBuildProperties extends BuildProperties {
   private val properties = new Properties()
   private val buildVersionKey = "build.version"
   private val buildSoftwareKey = "build.software"
@@ -35,4 +35,9 @@ object BuildProperties {
     try properties.load(is)
     finally if (is != null) is.close()
   }
+}
+
+trait BuildProperties {
+  val buildVersion: String
+  val projectName: String
 }

--- a/atum/src/main/scala/za/co/absa/atum/utils/DefaultBuildProperties.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/DefaultBuildProperties.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.utils
+
+import java.util.Properties
+
+object DefaultBuildProperties extends BuildProperties {
+  private val properties = new Properties()
+  private val buildVersionKey = "build.version"
+  private val buildSoftwareKey = "build.software"
+
+  /** Returns the version of the build. */
+  lazy val buildVersion: String = properties.getProperty(buildVersionKey)
+  /** Returns the name of the build. */
+  lazy val projectName: String = properties.getProperty(buildSoftwareKey)
+
+  loadConfig()
+
+  private def loadConfig(): Unit = {
+    val is = getClass.getResourceAsStream("/atum_build.properties")
+    try properties.load(is)
+    finally if (is != null) is.close()
+  }
+}

--- a/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilder.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilder.scala
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory
 import za.co.absa.atum.core.ControlType
 import za.co.absa.atum.model.CheckpointImplicits.CheckpointExt
 import za.co.absa.atum.model.{Checkpoint, ControlMeasure, ControlMeasureMetadata, Measurement}
+import za.co.absa.atum.utils.DefaultBuildProperties
 import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtils.getTimestampAsString
 
 import scala.util.Try
@@ -37,6 +38,7 @@ trait ControlMeasureBuilder {
   def withSourceType(sourceType: String): ControlMeasureBuilder
   def withInitialCheckpointName(initialCheckpointName: String): ControlMeasureBuilder
   def withWorkflowName(workflowName: String): ControlMeasureBuilder
+  def withSoftware(name: String, version: String): ControlMeasureBuilder
 
   def build: ControlMeasure
 }
@@ -82,7 +84,9 @@ object ControlMeasureBuilder {
                                                historyType: String = "Snapshot",
                                                sourceType: String = "Source",
                                                initialCheckpointName: String = "Source",
-                                               workflowName: String = "Source"
+                                               workflowName: String = "Source",
+                                               softwareName: String = DefaultBuildProperties.projectName,
+                                               softwareVersion: String = DefaultBuildProperties.buildVersion
                                               ) extends ControlMeasureBuilder {
 
     aggregateColumns.foreach { aggCol =>
@@ -111,6 +115,7 @@ object ControlMeasureBuilder {
     def withSourceType(sourceType: String): ControlMeasureBuilderImpl = this.copy(sourceType = sourceType)
     def withInitialCheckpointName(initialCheckpointName: String): ControlMeasureBuilderImpl = this.copy(initialCheckpointName = initialCheckpointName)
     def withWorkflowName(workflowName: String): ControlMeasureBuilderImpl = this.copy(workflowName = workflowName)
+    def withSoftware(name: String, version: String): ControlMeasureBuilder = this.copy(softwareName = name, softwareVersion = version)
 
     /**
      * Constructs a [[ControlMeasure]] data object (to be used for content as source _INFO file)
@@ -199,7 +204,7 @@ object ControlMeasureBuilder {
             controlCol = "*",
             controlValue = rowCount.toString
           ) :: aggegatedMeasurements.toList
-        ).withBuildProperties :: Nil)
+        ).withSoftware(softwareName, softwareVersion) :: Nil)
     }
   }
 

--- a/atum/src/test/scala/za/co/absa/atum/ControlInfoToJsonSerializationSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/ControlInfoToJsonSerializationSpec.scala
@@ -18,7 +18,7 @@ package za.co.absa.atum
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.atum.model.{Checkpoint, ControlMeasure, ControlMeasureMetadata, Measurement}
-import za.co.absa.atum.utils.{BuildProperties, SerializationUtils}
+import za.co.absa.atum.utils.{DefaultBuildProperties, SerializationUtils}
 import za.co.absa.atum.model.CheckpointImplicits.CheckpointExt
 import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtils
 
@@ -26,8 +26,8 @@ import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtils
   * Unit tests for ControlInfo object serialization
   */
 class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
-  private val version = BuildProperties.buildVersion
-  private val software = BuildProperties.projectName
+  private val version = DefaultBuildProperties.buildVersion
+  private val software = DefaultBuildProperties.projectName
 
   private val exampleCtrlInfo = ControlMeasure(
     metadata = ControlMeasureMetadata(
@@ -59,7 +59,7 @@ class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
           controlCol = "id",
           controlValue = "243"
         ))
-    ).withBuildProperties, Checkpoint(
+    ).withSoftware(), Checkpoint(
       name = "Raw",
       processStartTime = "01-01-2017 08:00:00",
       processEndTime = "01-01-2017 08:00:00",
@@ -79,7 +79,7 @@ class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
           controlValue = "243"
         )
       )
-    ).withBuildProperties
+    ).withSoftware()
     )
   )
 

--- a/atum/src/test/scala/za/co/absa/atum/ControlInfoToJsonSerializationSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/ControlInfoToJsonSerializationSpec.scala
@@ -146,7 +146,7 @@ class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
      |"controlValue":243
      |}]
      |}]
-     |}""".stripMargin.filter(_ >= ' ')
+     |}""".stripMargin.filter(_ >= ' ') // this works as the json is not expect to have any whitespaces in the values
 
   private val exampleInputJsonCustomSoftware: String = s"""{
     |"metadata":{
@@ -201,7 +201,7 @@ class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
     |"controlValue":243
     |}]
     |}]
-    |}""".stripMargin.filter(_ >= ' ')
+    |}""".stripMargin.filter(_ >= ' ') // this works as the json is not expect to have any whitespaces in the values
 
   private val exampleOutputJson: String = s"""{
      |"metadata":{
@@ -256,7 +256,7 @@ class ControlInfoToJsonSerializationSpec extends AnyFlatSpec with Matchers {
      |"controlValue":"243"
      |}]
      |}]
-     |}""".stripMargin.filter(_ >= ' ')
+     |}""".stripMargin.filter(_ >= ' ') // this works as the json is not expect to have any whitespaces in the values
 
   "toJson" should "serialize a ControlInfo object" in
   {

--- a/atum/src/test/scala/za/co/absa/atum/utils/BuildPropertiesSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/BuildPropertiesSpec.scala
@@ -21,8 +21,8 @@ import za.co.absa.commons.version.Version
 import scala.util.{Failure, Success, Try}
 
 class BuildPropertiesSpec extends AnyFlatSpec  {
-  private val version = BuildProperties.buildVersion
-  private val name = BuildProperties.projectName
+  private val version = DefaultBuildProperties.buildVersion
+  private val name = DefaultBuildProperties.projectName
 
   "Project version" should "be parsable by the semVer" in {
     Try {

--- a/examples/src/main/scala/za/co/absa/atum/examples/SampleMeasurements3.scala
+++ b/examples/src/main/scala/za/co/absa/atum/examples/SampleMeasurements3.scala
@@ -61,9 +61,8 @@ object SampleMeasurements3 extends Eventually {
     val measureObject1: ControlMeasure = SerializationUtils.fromJson[ControlMeasure](jsonInfoFile)
     val checkpoint = measureObject1.checkpoints.filter(_.name == "checkpoint1").head
 
-    if (checkpoint.software.isEmpty || checkpoint.version.isEmpty ||
-      !checkpoint.software.contains("MySoftware") || !checkpoint.version.contains("v007")) {
-      throw new Exception(s"Software or Version was not set properly. Gor name ${checkpoint.software} and version ${checkpoint.version}")
+    if (!checkpoint.software.contains("MySoftware") || !checkpoint.version.contains("v007")) {
+      throw new Exception(s"Software or Version was not set properly. Got name ${checkpoint.software} and version ${checkpoint.version}")
     }
 
     spark.disableControlMeasuresTracking()

--- a/examples/src/main/scala/za/co/absa/atum/examples/SampleMeasurements3.scala
+++ b/examples/src/main/scala/za/co/absa/atum/examples/SampleMeasurements3.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.examples
+
+import org.apache.hadoop.fs.FileSystem
+import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.scalatest.concurrent.Eventually
+import za.co.absa.atum.AtumImplicits._
+import za.co.absa.atum.utils.BuildProperties
+
+import java.nio.file.{Files, Paths}
+import scala.concurrent.duration.DurationInt // using basic Atum without extensions
+
+case class MyBuildProperties(projectName: String, buildVersion: String) extends BuildProperties
+
+object SampleMeasurements3 extends Eventually {
+  def main(args: Array[String]) {
+    val sparkBuilder = SparkSession.builder().appName("Sample Measurements 3 Job")
+    val spark = sparkBuilder.getOrCreate()
+
+    import spark.implicits._
+    val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
+    implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
+
+    // Initializing library to hook up to Apache Spark
+    spark.enableControlMeasuresTracking(Some("data/input/wikidata.csv.info"), None, MyBuildProperties("MySfotware", "v007"))
+      .setControlMeasuresWorkflow("Job 1")
+
+    // A business logic of a spark job ...
+
+    spark.read
+      .option("header", "true")
+      .option("inferSchema", "true")
+      .csv("data/input/wikidata.csv")
+      .as("source")
+      .filter($"total_response_size" > 1000)
+      .setCheckpoint("checkpoint1")
+      .write.mode(SaveMode.Overwrite)
+      .parquet("data/output/stage1_job_results")
+
+    eventually(timeout(scaled(10.seconds)), interval(scaled(500.millis))) {
+      if (!Files.exists(Paths.get("data/output/stage1_job_results/_INFO")))
+        throw new Exception("_INFO file not found at data/output/stage1_job_results")
+    }
+
+    spark.disableControlMeasuresTracking()
+  }
+}

--- a/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
+++ b/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
@@ -40,6 +40,7 @@ class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Match
   }
 
   private val inputCsv = "data/input/wikidata.csv"
+
   private def readSparkInputCsv(inputCsvPath: String): DataFrame = spark.read
     .option("header", "true")
     .option("inferSchema", "true")
@@ -55,75 +56,49 @@ class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Match
     }
   }
 
-  val outputPath = s"$tempDir/outputCheck1"
+  {
+    val outputPath = s"$tempDir/outputCheck1"
+    // implicit variant only writes to derived outputPath, explicit writes to both implicit derived path and the explicit one, too.
+    Seq(
+      ("implicit output _INFO path only", None, Seq(s"$outputPath/_INFO")),
+      ("implicit & explicit output _INFO path", Some(s"$outputPath/extra/_INFO2"), Seq(s"$outputPath/_INFO", s"$outputPath/extra/_INFO2"))
+    ).foreach { case (testCaseName, destinationOptInfoFilePath, expectedPaths) =>
 
-  "_INFO" should s"be written on spark.write (implicit output _INFO path only)" in {
-    val expectedPath = s"$outputPath/_INFO"
-    val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
-    implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
+      "_INFO" should s"be written on spark.write ($testCaseName)" in {
+        val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
+        implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
 
-    // Initializing library to hook up to Apache Spark
-    spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = None)
-      .setControlMeasuresWorkflow("Job 1")
+        // Initializing library to hook up to Apache Spark
+        spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = destinationOptInfoFilePath)
+          .setControlMeasuresWorkflow("Job 1")
 
-    import spark.implicits._
-    val df1 = readSparkInputCsv(inputCsv)
-    df1.setCheckpoint("Checkpoint0")
-    val filteredDf1 = df1.filter($"total_response_size" > 1000)
-    filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
-    writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
+        import spark.implicits._
+        val df1 = readSparkInputCsv(inputCsv)
+        df1.setCheckpoint("Checkpoint0")
+        val filteredDf1 = df1.filter($"total_response_size" > 1000)
+        filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
+        writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
 
-    spark.disableControlMeasuresTracking()
+        spark.disableControlMeasuresTracking()
 
-    log.info(s"Checking $expectedPath to contain expected values")
+        expectedPaths.foreach { expectedPath =>
+          log.info(s"Checking $expectedPath to contain expected values")
 
-    val infoControlMeasures =  eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
-      log.info(s"Reading $expectedPath")
-      val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
-      ControlMeasuresParser.fromJson(infoContentJson)
-    }
+          val infoControlMeasures = eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
+            log.info(s"Reading $expectedPath")
+            val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
+            ControlMeasuresParser.fromJson(infoContentJson)
+          }
 
-    infoControlMeasures.checkpoints.map(_.name) shouldBe Seq("Source", "Raw", "Checkpoint0", "Checkpoint1")
-    val checkpoint0 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint0" => c }.get
-    checkpoint0.controls should contain(Measurement("recordCount", "count", "*", "5000"))
+          infoControlMeasures.checkpoints.map(_.name) shouldBe Seq("Source", "Raw", "Checkpoint0", "Checkpoint1")
+          val checkpoint0 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint0" => c }.get
+          checkpoint0.controls should contain(Measurement("recordCount", "count", "*", "5000"))
 
-    val checkpoint1 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint1" => c }.get
-    checkpoint1.controls should contain(Measurement("recordCount", "count", "*", "4964"))
-  }
+          val checkpoint1 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint1" => c }.get
+          checkpoint1.controls should contain(Measurement("recordCount", "count", "*", "4964"))
+        }
 
-  "_INFO" should s"be written on spark.write (implicit & explicit output _INFO path)" in {
-    val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
-    implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
-
-    // Initializing library to hook up to Apache Spark
-    spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = Some(s"$outputPath/extra/_INFO2"))
-      .setControlMeasuresWorkflow("Job 1")
-
-    import spark.implicits._
-    val df1 = readSparkInputCsv(inputCsv)
-    df1.setCheckpoint("Checkpoint0")
-    val filteredDf1 = df1.filter($"total_response_size" > 1000)
-    filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
-    writeSparkData(filteredDf1, outputPath, Some(s"$outputPath/extra/_INFO2")) // implicit output _INFO file path is derived from this path passed to spark.write
-
-    spark.disableControlMeasuresTracking()
-
-    Seq(s"$outputPath/_INFO", s"$outputPath/extra/_INFO2").foreach { expectedPath =>
-      log.info(s"Checking $expectedPath to contain expected values")
-
-      val infoControlMeasures =  eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
-        log.info(s"Reading $expectedPath")
-        val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
-        ControlMeasuresParser.fromJson(infoContentJson)
       }
-
-      infoControlMeasures.checkpoints.map(_.name) shouldBe Seq("Source", "Raw", "Checkpoint0", "Checkpoint1")
-      val checkpoint0 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint0" => c }.get
-      checkpoint0.controls should contain(Measurement("recordCount", "count", "*", "5000"))
-
-      val checkpoint1 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint1" => c }.get
-      checkpoint1.controls should contain(Measurement("recordCount", "count", "*", "4964"))
     }
   }
-
 }

--- a/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
+++ b/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
@@ -62,18 +62,20 @@ class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Match
     val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
     implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
 
-    // Initializing library to hook up to Apache Spark
-    spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = None)
-      .setControlMeasuresWorkflow("Job 1")
+    synchronized {
+      // Initializing library to hook up to Apache Spark
+      spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = None)
+        .setControlMeasuresWorkflow("Job 1")
 
-    import spark.implicits._
-    val df1 = readSparkInputCsv(inputCsv)
-    df1.setCheckpoint("Checkpoint0")
-    val filteredDf1 = df1.filter($"total_response_size" > 1000)
-    filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
-    writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
+      import spark.implicits._
+      val df1 = readSparkInputCsv(inputCsv)
+      df1.setCheckpoint("Checkpoint0")
+      val filteredDf1 = df1.filter($"total_response_size" > 1000)
+      filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
+      writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
 
-    spark.disableControlMeasuresTracking()
+      spark.disableControlMeasuresTracking()
+    }
 
     log.info(s"Checking $expectedPath to contain expected values")
 
@@ -95,18 +97,20 @@ class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Match
     val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
     implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
 
-    // Initializing library to hook up to Apache Spark
-    spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = Some(s"$outputPath/extra/_INFO2"))
-      .setControlMeasuresWorkflow("Job 1")
+    synchronized {
+      // Initializing library to hook up to Apache Spark
+      spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = Some(s"$outputPath/extra/_INFO2"))
+        .setControlMeasuresWorkflow("Job 1")
 
-    import spark.implicits._
-    val df1 = readSparkInputCsv(inputCsv)
-    df1.setCheckpoint("Checkpoint0")
-    val filteredDf1 = df1.filter($"total_response_size" > 1000)
-    filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
-    writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
+      import spark.implicits._
+      val df1 = readSparkInputCsv(inputCsv)
+      df1.setCheckpoint("Checkpoint0")
+      val filteredDf1 = df1.filter($"total_response_size" > 1000)
+      filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
+      writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
 
-    spark.disableControlMeasuresTracking()
+      spark.disableControlMeasuresTracking()
+    }
 
     Seq(s"$outputPath/_INFO", s"$outputPath/extra/_INFO2").foreach { expectedPath =>
       log.info(s"Checking $expectedPath to contain expected values")

--- a/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
+++ b/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
@@ -15,24 +15,20 @@
 
 package za.co.absa.atum
 
-import java.nio.file.{Files, Paths}
-
 import org.apache.hadoop.fs.FileSystem
 import org.apache.log4j.LogManager
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
-import org.scalatest.flatspec.{AnyFlatSpec, AsyncFlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.specs2.matcher.Matchers.concurrentExecutionContext
+import za.co.absa.atum.AtumImplicits._
 import za.co.absa.atum.model.{Checkpoint, Measurement}
 import za.co.absa.atum.persistence.ControlMeasuresParser
 import za.co.absa.atum.utils.SparkTestBase
-import za.co.absa.atum.AtumImplicits._
 
-import scala.concurrent.duration.{Duration, DurationInt}
-import scala.concurrent.{Await, Future}
+import java.nio.file.{Files, Paths}
+import scala.concurrent.duration.DurationInt
 
 class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Matchers with BeforeAndAfterAll with Eventually {
 
@@ -59,48 +55,75 @@ class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Match
     }
   }
 
-  {
-    val outputPath = s"$tempDir/outputCheck1"
-    // implicit variant only writes to derived outputPath, explicit writes to both implicit derived path and the explicit one, too.
-    Seq(
-      ("implicit output _INFO path only", None, Seq(s"$outputPath/_INFO")),
-      ("implicit & explicit output _INFO path", Some(s"$outputPath/extra/_INFO2"), Seq(s"$outputPath/_INFO", s"$outputPath/extra/_INFO2"))
-    ).foreach { case (testCaseName, destinationOptInfoFilePath, expectedPaths) =>
+  val outputPath = s"$tempDir/outputCheck1"
 
-      "_INFO" should s"be written on spark.write ($testCaseName)" in {
-        val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
-        implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
+  "_INFO" should s"be written on spark.write (implicit output _INFO path only)" in {
+    val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
+    implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
 
-        // Initializing library to hook up to Apache Spark
-        spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = destinationOptInfoFilePath)
-          .setControlMeasuresWorkflow("Job 1")
+    // Initializing library to hook up to Apache Spark
+    spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = None)
+      .setControlMeasuresWorkflow("Job 1")
 
-        import spark.implicits._
-        val df1 = readSparkInputCsv(inputCsv)
-        df1.setCheckpoint("Checkpoint0")
-        val filteredDf1 = df1.filter($"total_response_size" > 1000)
-        filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
-        writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
+    import spark.implicits._
+    val df1 = readSparkInputCsv(inputCsv)
+    df1.setCheckpoint("Checkpoint0")
+    val filteredDf1 = df1.filter($"total_response_size" > 1000)
+    filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
+    writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
 
-        spark.disableControlMeasuresTracking()
+    spark.disableControlMeasuresTracking()
 
-        expectedPaths.foreach { expectedPath =>
-          log.info(s"Checking $expectedPath to contain expected values")
+    Seq(s"$outputPath/_INFO").foreach { expectedPath =>
+      log.info(s"Checking $expectedPath to contain expected values")
 
-          val infoControlMeasures =  eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
-            log.info(s"Reading $expectedPath")
-            val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
-            ControlMeasuresParser.fromJson(infoContentJson)
-          }
-
-          infoControlMeasures.checkpoints.map(_.name) shouldBe Seq("Source", "Raw", "Checkpoint0", "Checkpoint1")
-          val checkpoint0 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint0" => c }.get
-          checkpoint0.controls should contain(Measurement("recordCount", "count", "*", "5000"))
-
-          val checkpoint1 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint1" => c }.get
-          checkpoint1.controls should contain(Measurement("recordCount", "count", "*", "4964"))
-        }
+      val infoControlMeasures =  eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
+        log.info(s"Reading $expectedPath")
+        val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
+        ControlMeasuresParser.fromJson(infoContentJson)
       }
+
+      infoControlMeasures.checkpoints.map(_.name) shouldBe Seq("Source", "Raw", "Checkpoint0", "Checkpoint1")
+      val checkpoint0 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint0" => c }.get
+      checkpoint0.controls should contain(Measurement("recordCount", "count", "*", "5000"))
+
+      val checkpoint1 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint1" => c }.get
+      checkpoint1.controls should contain(Measurement("recordCount", "count", "*", "4964"))
+    }
+  }
+
+  "_INFO" should s"be written on spark.write (implicit & explicit output _INFO path)" in {
+    val hadoopConfiguration = spark.sparkContext.hadoopConfiguration
+    implicit val fs: FileSystem = FileSystem.get(hadoopConfiguration)
+
+    // Initializing library to hook up to Apache Spark
+    spark.enableControlMeasuresTracking(sourceInfoFilePath = Some("data/input/wikidata.csv.info"), destinationInfoFilePath = Some(s"$outputPath/extra/_INFO2"))
+      .setControlMeasuresWorkflow("Job 1")
+
+    import spark.implicits._
+    val df1 = readSparkInputCsv(inputCsv)
+    df1.setCheckpoint("Checkpoint0")
+    val filteredDf1 = df1.filter($"total_response_size" > 1000)
+    filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
+    writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
+
+    spark.disableControlMeasuresTracking()
+
+    Seq(s"$outputPath/_INFO", s"$outputPath/extra/_INFO2").foreach { expectedPath =>
+      log.info(s"Checking $expectedPath to contain expected values")
+
+      val infoControlMeasures =  eventually(timeout(scaled(10.seconds)), interval(scaled(2.seconds))) {
+        log.info(s"Reading $expectedPath")
+        val infoContentJson = LocalFsTestUtils.readFileAsString(expectedPath)
+        ControlMeasuresParser.fromJson(infoContentJson)
+      }
+
+      infoControlMeasures.checkpoints.map(_.name) shouldBe Seq("Source", "Raw", "Checkpoint0", "Checkpoint1")
+      val checkpoint0 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint0" => c }.get
+      checkpoint0.controls should contain(Measurement("recordCount", "count", "*", "5000"))
+
+      val checkpoint1 = infoControlMeasures.checkpoints.collectFirst { case c: Checkpoint if c.name == "Checkpoint1" => c }.get
+      checkpoint1.controls should contain(Measurement("recordCount", "count", "*", "4964"))
     }
   }
 

--- a/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
+++ b/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
@@ -77,7 +77,7 @@ class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Match
         df1.setCheckpoint("Checkpoint0")
         val filteredDf1 = df1.filter($"total_response_size" > 1000)
         filteredDf1.setCheckpoint("Checkpoint1") // stateful, do not need return value
-        writeSparkData(filteredDf1, outputPath) // implicit output _INFO file path is derived from this path passed to spark.write
+        writeSparkData(filteredDf1, outputPath, destinationOptInfoFilePath) // implicit output _INFO file path is derived from this path passed to spark.write
 
         spark.disableControlMeasuresTracking()
 

--- a/examples/src/test/scala/za/co/absa/atum/examples/SampleMeasurementsHdfsRunnerSpec.scala
+++ b/examples/src/test/scala/za/co/absa/atum/examples/SampleMeasurementsHdfsRunnerSpec.scala
@@ -25,4 +25,5 @@ class SampleMeasurementsHdfsRunnerSpec extends AnyFunSuite
     // SampleMeasurement2 depends on SampleMeasurements1's output, so they must be run in this order
     runSparkJobAsTest[SampleMeasurements1.type]
     runSparkJobAsTest[SampleMeasurements2.type]
+    runSparkJobAsTest[SampleMeasurements3.type]
 }


### PR DESCRIPTION
I first want to sanity check my approach with you guys.

- build properties refactored to be testable (will split into two files with next commit)
- added `withSoftware` method to the builder. Replaces `withBuildProperties`
- pass BuildProperties to the accumulator and possibly with `enableControlMeasuresTracking`

And after the discussion
- will add new unit tests in next commit
- will add new comments

Fixes #85 