### PR TITLE
#97 Aggregate control type strategy

### DIFF
--- a/atum/src/main/scala/za/co/absa/atum/core/ControlType.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/ControlType.scala
@@ -23,11 +23,15 @@ object ControlType {
   case object AbsAggregatedTotal extends ControlType("absAggregatedTotal")
   case object HashCrc32 extends ControlType("hashCrc32")
 
-  val values = Seq(Count.value, DistinctCount.value, AggregatedTotal.value, AbsAggregatedTotal.value, HashCrc32.value)
+  val values = Seq(Count, DistinctCount, AggregatedTotal, AbsAggregatedTotal, HashCrc32)
+  val valueStrings = values.map(_.value)
 
-  def getNormalizedValue(input: String): String = {
-    values.find(value => isControlMeasureTypeEqual(input, value)).getOrElse(input)
+  def getNormalizedStringValue(input: String): String = {
+    valueStrings.find(value => isControlMeasureTypeEqual(input, value)).getOrElse(input)
   }
+
+  def withValueName(s: String): ControlType = values.find(_.value.toString == s).getOrElse(
+    throw new NoSuchElementException(s"No value found for '$s'. Allowed values are: $valueStrings"))
 
   def isControlMeasureTypeEqual(x: String, y: String): Boolean = {
     if (x.toLowerCase == y.toLowerCase) {

--- a/atum/src/main/scala/za/co/absa/atum/core/ControlType.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/ControlType.scala
@@ -23,15 +23,15 @@ object ControlType {
   case object AbsAggregatedTotal extends ControlType("absAggregatedTotal")
   case object HashCrc32 extends ControlType("hashCrc32")
 
-  val values = Seq(Count, DistinctCount, AggregatedTotal, AbsAggregatedTotal, HashCrc32)
-  val valueStrings = values.map(_.value)
+  val values: Seq[ControlType] = Seq(Count, DistinctCount, AggregatedTotal, AbsAggregatedTotal, HashCrc32)
+  val valueNames: Seq[String] = values.map(_.value)
 
-  def getNormalizedStringValue(input: String): String = {
-    valueStrings.find(value => isControlMeasureTypeEqual(input, value)).getOrElse(input)
+  def getNormalizedValueName(input: String): String = {
+    valueNames.find(value => isControlMeasureTypeEqual(input, value)).getOrElse(input)
   }
 
   def withValueName(s: String): ControlType = values.find(_.value.toString == s).getOrElse(
-    throw new NoSuchElementException(s"No value found for '$s'. Allowed values are: $valueStrings"))
+    throw new NoSuchElementException(s"No value found for '$s'. Allowed values are: $valueNames"))
 
   def isControlMeasureTypeEqual(x: String, y: String): Boolean = {
     if (x.toLowerCase == y.toLowerCase) {

--- a/atum/src/main/scala/za/co/absa/atum/core/ControlType.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/ControlType.scala
@@ -25,7 +25,7 @@ object ControlType {
 
   val values = Seq(Count.value, DistinctCount.value, AggregatedTotal.value, AbsAggregatedTotal.value, HashCrc32.value)
 
-  def getNormalizedValue(input: String) = {
+  def getNormalizedValue(input: String): String = {
     values.find(value => isControlMeasureTypeEqual(input, value)).getOrElse(input)
   }
 

--- a/atum/src/main/scala/za/co/absa/atum/core/ControlType.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/ControlType.scala
@@ -15,13 +15,13 @@
 
 package za.co.absa.atum.core
 
-class ControlType(val value: String)
+class ControlType(val value: String, val onlyForNumeric: Boolean)
 object ControlType {
-  case object Count extends ControlType("count")
-  case object DistinctCount extends ControlType("distinctCount")
-  case object AggregatedTotal extends ControlType("aggregatedTotal")
-  case object AbsAggregatedTotal extends ControlType("absAggregatedTotal")
-  case object HashCrc32 extends ControlType("hashCrc32")
+  case object Count extends ControlType("count", false)
+  case object DistinctCount extends ControlType("distinctCount", false)
+  case object AggregatedTotal extends ControlType("aggregatedTotal", true)
+  case object AbsAggregatedTotal extends ControlType("absAggregatedTotal", true)
+  case object HashCrc32 extends ControlType("hashCrc32", false)
 
   val values: Seq[ControlType] = Seq(Count, DistinctCount, AggregatedTotal, AbsAggregatedTotal, HashCrc32)
   val valueNames: Seq[String] = values.map(_.value)

--- a/atum/src/main/scala/za/co/absa/atum/core/MeasurementProcessor.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/MeasurementProcessor.scala
@@ -17,23 +17,109 @@ package za.co.absa.atum.core
 
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{DecimalType, LongType, StringType}
-import org.apache.spark.sql.{Column, Dataset, Row}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
 import za.co.absa.atum.core.ControlType._
+import za.co.absa.atum.core.MeasurementProcessor.MeasurementFunction
 import za.co.absa.atum.model.Measurement
 import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtils
+
+import scala.util.{Failure, Success, Try}
+
+object MeasurementProcessor {
+  type MeasurementFunction = DataFrame => String
+
+  private val valueColumnName: String = "value"
+
+  /**
+   * Assembles the measurement function based for controlCol based on the controlType
+   * @param controlCol
+   * @param controlType
+   * @return
+   */
+  private[atum] def getMeasurementFunction(controlCol: String, controlType: ControlType): MeasurementFunction = {
+    controlType match {
+      case Count => (ds: Dataset[Row]) => ds.count().toString
+      case DistinctCount => (ds: Dataset[Row]) => {
+        ds.select(col(controlCol)).distinct().count().toString
+      }
+      case AggregatedTotal =>
+        (ds: Dataset[Row]) => {
+          val aggCol = sum(col(valueColumnName))
+          aggregateColumn(ds, controlCol, aggCol)
+        }
+      case AbsAggregatedTotal =>
+        (ds: Dataset[Row]) => {
+          val aggCol = sum(abs(col(valueColumnName)))
+          aggregateColumn(ds, controlCol, aggCol)
+        }
+      case HashCrc32 =>
+        (ds: Dataset[Row]) => {
+          val aggColName = ControlMeasureUtils.getTemporaryColumnName(ds)
+          val v = ds.withColumn(aggColName, crc32(col(controlCol).cast("String")))
+            .agg(sum(col(aggColName))).collect()(0)(0)
+          if (v == null) "" else v.toString
+        }
+    }
+  }
+
+  private def aggregateColumn(ds: Dataset[Row], measureColumn: String, aggExpression: Column): String = {
+    val dataType = ds.select(measureColumn).schema.fields(0).dataType
+    val aggregatedValue = dataType match {
+      case _: LongType =>
+        // This is protection against long overflow, e.g. Long.MaxValue = 9223372036854775807:
+        //   scala> sc.parallelize(List(Long.MaxValue, 1)).toDF.agg(sum("value")).take(1)(0)(0)
+        //   res11: Any = -9223372036854775808
+        // Converting to BigDecimal fixes the issue
+        //val ds2 = ds.select(col(measurement.controlCol).cast(DecimalType(38, 0)).as("value"))
+        //ds2.agg(sum(abs($"value"))).collect()(0)(0)
+        val ds2 = ds.select(col(measureColumn).cast(DecimalType(38, 0)).as(valueColumnName))
+        val collected = ds2.agg(aggExpression).collect()(0)(0)
+        if (collected == null) 0 else collected
+      case _: StringType =>
+        // Support for string type aggregation
+        val ds2 = ds.select(col(measureColumn).cast(DecimalType(38, 18)).as(valueColumnName))
+        val collected = ds2.agg(aggExpression).collect()(0)(0)
+        val value = if (collected==null) new java.math.BigDecimal(0) else collected.asInstanceOf[java.math.BigDecimal]
+        value
+          .stripTrailingZeros    // removes trailing zeros (2001.500000 -> 2001.5, but can introduce scientific notation (600.000 -> 6E+2)
+          .toPlainString         // converts to normal string (6E+2 -> "600")
+      case _ =>
+        val ds2 = ds.select(col(measureColumn).as(valueColumnName))
+        val collected = ds2.agg(aggExpression).collect()(0)(0)
+        if (collected == null) 0 else collected
+    }
+    //check if total is required to be presented as larger type - big decimal
+    workaroundBigDecimalIssues(aggregatedValue)
+  }
+
+  private def workaroundBigDecimalIssues(value: Any): String = {
+    // If aggregated value is java.math.BigDecimal, convert it to scala.math.BigDecimal
+    value match {
+      case v: java.math.BigDecimal =>
+        // Convert the value to string to workaround different serializers generate different JSONs for BigDecimal
+        v.stripTrailingZeros    // removes trailing zeros (2001.500000 -> 2001.5, but can introduce scientific notation (600.000 -> 6E+2)
+          .toPlainString         // converts to normal string (6E+2 -> "600")
+      case v: BigDecimal =>
+        // Convert the value to string to workaround different serializers generate different JSONs for BigDecimal
+        new java.math.BigDecimal(v.toString())
+          .stripTrailingZeros    // removes trailing zeros (2001.500000 -> 2001.5, but can introduce scientific notation (600.000 -> 6E+2)
+          .toPlainString         // converts to normal string (6E+2 -> "600")
+      case a => a.toString
+    }
+  }
+
+}
 
 /**
   * This class is used for processing Spark Dataset to calculate aggregates / control measures
   */
 class MeasurementProcessor(private var measurements: Seq[Measurement]) {
-  type MeasurementFunction = Dataset[Row] => String
   type MeasurementProcessor = (Measurement, MeasurementFunction)
 
   // Assigning measurement function to each measurement
   var processors: Seq[MeasurementProcessor] =
     measurements.map(m => (m, getMeasurementFunction(m)))
 
-  private val valueColumnName: String = "value"
 
   /** The method calculates measurements for each control.  */
   private[atum] def measureDataset(ds: Dataset[Row]): Seq[Measurement] = {
@@ -72,80 +158,18 @@ class MeasurementProcessor(private var measurements: Seq[Measurement]) {
 
   /** The method maps string representation of control type to measurement function.  */
   private def getMeasurementFunction(measurement: Measurement): MeasurementFunction = {
-
-    measurement.controlType match {
-      case Count.value => (ds: Dataset[Row]) => ds.count().toString
-      case DistinctCount.value => (ds: Dataset[Row]) => {
-          ds.select(col(measurement.controlCol)).distinct().count().toString
-      }
-      case AggregatedTotal.value =>
-        (ds: Dataset[Row]) => {
-          val aggCol = sum(col(valueColumnName))
-          aggregateColumn(ds, measurement.controlCol, aggCol)
-        }
-      case AbsAggregatedTotal.value =>
-        (ds: Dataset[Row]) => {
-          val aggCol = sum(abs(col(valueColumnName)))
-          aggregateColumn(ds, measurement.controlCol, aggCol)
-        }
-      case HashCrc32.value =>
-        (ds: Dataset[Row]) => {
-          val aggColName = ControlMeasureUtils.getTemporaryColumnName(ds)
-          val v = ds.withColumn(aggColName, crc32(col(measurement.controlCol).cast("String")))
-            .agg(sum(col(aggColName))).collect()(0)(0)
-          if (v == null) "" else v.toString
-        }
-      case _ =>
+    Try {
+      ControlType.withValueName(measurement.controlType)
+    } match {
+      case Failure(exception) =>
         Atum.log.error(s"Unrecognized control measurement type '${measurement.controlType}'. Available control measurement types are: " +
           s"${ControlType.values.mkString(",")}.")
+        Atum.log.error(exception.getLocalizedMessage)
         (_: Dataset[Row]) => "N/A"
-    }
-  }
 
-  private def workaroundBigDecimalIssues(value: Any): String = {
-    // If aggregated value is java.math.BigDecimal, convert it to scala.math.BigDecimal
-    value match {
-      case v: java.math.BigDecimal =>
-        // Convert the value to string to workaround different serializers generate different JSONs for BigDecimal
-        v.stripTrailingZeros    // removes trailing zeros (2001.500000 -> 2001.5, but can introduce scientific notation (600.000 -> 6E+2)
-         .toPlainString         // converts to normal string (6E+2 -> "600")
-      case v: BigDecimal =>
-        // Convert the value to string to workaround different serializers generate different JSONs for BigDecimal
-        new java.math.BigDecimal(v.toString())
-          .stripTrailingZeros    // removes trailing zeros (2001.500000 -> 2001.5, but can introduce scientific notation (600.000 -> 6E+2)
-          .toPlainString         // converts to normal string (6E+2 -> "600")
-      case a => a.toString
+      case Success(controlType) =>
+        MeasurementProcessor.getMeasurementFunction(measurement.controlCol, controlType)
     }
-  }
-
-  private def aggregateColumn(ds: Dataset[Row], measureColumn: String, aggExpression: Column): String = {
-    val dataType = ds.select(measureColumn).schema.fields(0).dataType
-    val aggregatedValue = dataType match {
-      case _: LongType =>
-        // This is protection against long overflow, e.g. Long.MaxValue = 9223372036854775807:
-        //   scala> sc.parallelize(List(Long.MaxValue, 1)).toDF.agg(sum("value")).take(1)(0)(0)
-        //   res11: Any = -9223372036854775808
-        // Converting to BigDecimal fixes the issue
-        //val ds2 = ds.select(col(measurement.controlCol).cast(DecimalType(38, 0)).as("value"))
-        //ds2.agg(sum(abs($"value"))).collect()(0)(0)
-        val ds2 = ds.select(col(measureColumn).cast(DecimalType(38, 0)).as(valueColumnName))
-        val collected = ds2.agg(aggExpression).collect()(0)(0)
-        if (collected == null) 0 else collected
-      case _: StringType =>
-        // Support for string type aggregation
-        val ds2 = ds.select(col(measureColumn).cast(DecimalType(38, 18)).as(valueColumnName))
-        val collected = ds2.agg(aggExpression).collect()(0)(0)
-        val value = if (collected==null) new java.math.BigDecimal(0) else collected.asInstanceOf[java.math.BigDecimal]
-        value
-          .stripTrailingZeros    // removes trailing zeros (2001.500000 -> 2001.5, but can introduce scientific notation (600.000 -> 6E+2)
-          .toPlainString         // converts to normal string (6E+2 -> "600")
-      case _ =>
-        val ds2 = ds.select(col(measureColumn).as(valueColumnName))
-        val collected = ds2.agg(aggExpression).collect()(0)(0)
-        if (collected == null) 0 else collected
-    }
-    //check if total is required to be presented as larger type - big decimal
-    workaroundBigDecimalIssues(aggregatedValue)
   }
 
 }

--- a/atum/src/main/scala/za/co/absa/atum/core/MeasurementProcessor.scala
+++ b/atum/src/main/scala/za/co/absa/atum/core/MeasurementProcessor.scala
@@ -38,7 +38,8 @@ object MeasurementProcessor {
    */
   private[atum] def getMeasurementFunction(controlCol: String, controlType: ControlType): MeasurementFunction = {
     controlType match {
-      case Count => (ds: Dataset[Row]) => ds.count().toString
+      case Count => (ds: Dataset[Row]) =>
+        ds.select(col(controlCol)).count().toString
       case DistinctCount => (ds: Dataset[Row]) => {
         ds.select(col(controlCol)).distinct().count().toString
       }

--- a/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilder.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilder.scala
@@ -99,8 +99,6 @@ object ControlMeasureBuilder {
    */
   private case class ControlMeasureBuilderImpl(df: DataFrame,
                                                aggregateColumnMappings: Seq[ControlTypeMapping] = Seq.empty,
-                                               aggregateControlTypeStrategy: ControlTypeStrategy
-                                               = ControlTypeStrategy.Default,
                                                sourceApplication: String = "",
                                                inputPathName: String = "",
                                                reportDate: String = ControlMeasureUtils.getTodayAsString,

--- a/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilder.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilder.scala
@@ -19,17 +19,22 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{abs, col, crc32, sum}
 import org.apache.spark.sql.types.{DecimalType, LongType, NumericType}
 import org.slf4j.LoggerFactory
-import za.co.absa.atum.core.ControlType
+import za.co.absa.atum.core.{Atum, ControlType, MeasurementProcessor}
 import za.co.absa.atum.model.CheckpointImplicits.CheckpointExt
 import za.co.absa.atum.model.{Checkpoint, ControlMeasure, ControlMeasureMetadata, Measurement}
-import za.co.absa.atum.utils.controlmeasure.ControlMeasureBuilder.AggregateControlTypeStrategy
+import za.co.absa.atum.utils.controlmeasure.ControlMeasureBuilder.ControlTypeStrategy
+import za.co.absa.atum.utils.controlmeasure.ControlMeasureBuilder.ControlTypeStrategy._
 import za.co.absa.atum.utils.controlmeasure.ControlMeasureUtils.getTimestampAsString
 
 import scala.util.Try
 
 trait ControlMeasureBuilder {
-  def withAggregateColumns(aggregateColumns: Seq[String],
-                           strategy: AggregateControlTypeStrategy = AggregateControlTypeStrategy.Default): ControlMeasureBuilder
+
+  def withAggregateColumn(columnName: String, strategy: ControlTypeStrategy = ControlTypeStrategy.Default): ControlMeasureBuilder
+  def withAggregateColumn(columnName: String, controlType: ControlType): ControlMeasureBuilder
+  def withAggregateColumns(columnNames: Seq[String], strategy: ControlTypeStrategy = ControlTypeStrategy.Default): ControlMeasureBuilder
+  def withAggregateColumns(controlTypeMappings: Seq[(String, ControlType)]): ControlMeasureBuilder
+
   def withSourceApplication(sourceApplication: String): ControlMeasureBuilder
   def withInputPath(inputPath: String): ControlMeasureBuilder
   def withReportDate(reportDate: String): ControlMeasureBuilder
@@ -46,28 +51,23 @@ trait ControlMeasureBuilder {
 
 object ControlMeasureBuilder {
 
-  sealed trait AggregateControlTypeStrategy
-  object AggregateControlTypeStrategy {
+  sealed trait ControlTypeStrategy
+  object ControlTypeStrategy {
+
+    private[controlmeasure] case class ControlTypeMapping(columnName: String, strategy: ControlTypeStrategy = Default)
 
     /**
      * For numeric types controlType.absAggregatedTotal and for non-numeric controlType.HashCrc32 is used.
      */
-    case object Default extends AggregateControlTypeStrategy
+    case object Default extends ControlTypeStrategy
 
     /**
-     * This controlType will be attempted to used fro all aggregateColumns. If unusable
+     * Specify the concrete control types to be used. If unusable
      * (e.g. AggregatedTotal or AbsAggregatedTotal for non-numeric, controlType is fallbacked by using the Default.
      *
      * @param controlType single controlType to be attempted to used for all aggregateColumns
      */
-    case class Common(controlType: ControlType) extends AggregateControlTypeStrategy
-
-    /**
-     * Specify the concrete control types to be used, in order of the aggregateColumns.
-     * @param controlTypes sequence to use for aggregateColumns
-     */
-    case class Specific(controlTypes: Seq[ControlType]) extends AggregateControlTypeStrategy
-
+    case class Specific(controlType: ControlType) extends ControlTypeStrategy
   }
 
   /**
@@ -79,30 +79,29 @@ object ControlMeasureBuilder {
   def forDF(df: DataFrame): ControlMeasureBuilder =
     ControlMeasureBuilderImpl(df)
 
-
   /**
    * This class can be used to construct a [[ControlMeasure]] data object (to be used for content as source _INFO file)
    * for a given dataframe using the `build` "method" after all necessary fields have been set.
    *
    * The row count measurement is added automatically. You can also specify aggregation columns for aggregation measurements
    *
-   * @param df                    A dataframe for which _INFO file to be created.
-   * @param aggregateColumns      Column names for `df`.
-   * @param sourceApplication     The name of the application providing the data (default = "").
-   * @param inputPathName         The path to the input file name. Can be a folder with file mask (default = "").
-   * @param reportDate            The date of the data generation (default = today).
-   * @param reportVersion         The version of the data generation for the date, new versions replace old  versions of data (default = 1).
-   * @param country               Country name (default = "ZA").
-   * @param historyType           History type (default = "Snapshot").
-   * @param sourceType            Source type (default = "Source").
-   * @param initialCheckpointName The name of the initial checkpoint (default = "Source").
-   * @param workflowName          A workflow name to group several checkpoint sth in the chain (default = "Source").
+   * @param df                        A dataframe for which _INFO file to be created.
+   * @param aggregateColumnMappings   Column names for `df` and their ControlTypeMappings (Default or Specific for each col)
+   * @param sourceApplication         The name of the application providing the data (default = "").
+   * @param inputPathName             The path to the input file name. Can be a folder with file mask (default = "").
+   * @param reportDate                The date of the data generation (default = today).
+   * @param reportVersion             The version of the data generation for the date, new versions replace old  versions of data (default = 1).
+   * @param country                   Country name (default = "ZA").
+   * @param historyType               History type (default = "Snapshot").
+   * @param sourceType                Source type (default = "Source").
+   * @param initialCheckpointName     The name of the initial checkpoint (default = "Source").
+   * @param workflowName              A workflow name to group several checkpoint sth in the chain (default = "Source").
    *
    */
   private case class ControlMeasureBuilderImpl(df: DataFrame,
-                                               aggregateColumns: Seq[String] = Seq.empty,
-                                               aggregateControlTypeStrategy: AggregateControlTypeStrategy
-                                               = AggregateControlTypeStrategy.Default,
+                                               aggregateColumnMappings: Seq[ControlTypeMapping] = Seq.empty,
+                                               aggregateControlTypeStrategy: ControlTypeStrategy
+                                               = ControlTypeStrategy.Default,
                                                sourceApplication: String = "",
                                                inputPathName: String = "",
                                                reportDate: String = ControlMeasureUtils.getTodayAsString,
@@ -114,9 +113,9 @@ object ControlMeasureBuilder {
                                                workflowName: String = "Source"
                                               ) extends ControlMeasureBuilder {
 
-    aggregateColumns.foreach { aggCol =>
-      require(df.columns.contains(aggCol),
-        s"Aggregate columns must be present in dataframe, but '$aggCol' was not found there. Columns found: ${df.columns.mkString(", ")}."
+    aggregateColumnMappings.foreach { aggCol =>
+      require(df.columns.contains(aggCol.columnName),
+        s"Aggregate columns must be present in dataframe, but '${aggCol.columnName}' was not found there. Columns found: ${df.columns.mkString(", ")}."
       )
     }
 
@@ -126,28 +125,38 @@ object ControlMeasureBuilder {
     def withSourceApplication(sourceApplication: String): ControlMeasureBuilderImpl = this.copy(sourceApplication = sourceApplication)
     def withInputPath(inputPath: String): ControlMeasureBuilderImpl = this.copy(inputPathName = inputPath)
 
-    def withAggregateColumns(aggregateColumns: Seq[String], strategy: AggregateControlTypeStrategy): ControlMeasureBuilderImpl = {
-      require(aggregateColumns.nonEmpty, "aggregateColumns must not be empty!")
 
-      import AggregateControlTypeStrategy._
-      strategy match {
-        case Default =>
-          // numeric check:
-        case Common(controlType) if controlType == ControlType.AbsAggregatedTotal || controlType == ControlType.AggregatedTotal => {
-          val nonNumericFields = df.select(aggregateColumns.map(col):_*)
-            .schema.filter( field => !field.dataType.isInstanceOf[NumericType])
-          logger.warn(s"Aggregate columns ${nonNumericFields.map(field => s"${field.name} (${field.dataType})").mkString(",")} " +
-            s"are not numeric, but controlType strategy $strategy was set up. Default strategy will be used instead.")
-        }
-        case Specific(controlTypes) =>
-          if (aggregateColumns.length != controlTypes.length) {
-            logger.warn(s"AggregateColumns(${aggregateColumns.length}, $aggregateColumns) size does not conform " +
-              s"the length of list of control types (${controlTypes.length}, $controlTypes). Default strategy might be used.")
-          }
-      }
 
-      this.copy(aggregateColumns = aggregateColumns, aggregateControlTypeStrategy = strategy)
+    def withAggregateColumn(columnName: String, strategy: ControlTypeStrategy = Default): ControlMeasureBuilderImpl = {
+      val mapping = ControlTypeMapping(columnName, strategy)
+      this.withAggregateColumn(mapping)
     }
+
+    def withAggregateColumn(columnName: String, controlType: ControlType): ControlMeasureBuilderImpl = {
+      val mapping = ControlTypeMapping(columnName, Specific(controlType))
+      this.withAggregateColumn(mapping)
+    }
+
+    private def withAggregateColumn(mapping: ControlTypeMapping): ControlMeasureBuilderImpl = {
+      this.copy(aggregateColumnMappings = this.aggregateColumnMappings :+ mapping)
+    }
+
+    def withAggregateColumns(columnNames: Seq[String], strategy:ControlTypeStrategy = Default): ControlMeasureBuilderImpl = {
+      val mappings = columnNames.map(ControlTypeMapping(_))
+      this.withAggregateColumnsDirectly(mappings)
+    }
+
+    def withAggregateColumns(controlTypeMappings: Seq[(String, ControlType)]): ControlMeasureBuilderImpl = {
+      val mappings = controlTypeMappings.map { case (name, controlType) =>
+        ControlTypeMapping(name, Specific(controlType))
+      }
+      this.withAggregateColumnsDirectly(mappings)
+    }
+
+    private def withAggregateColumnsDirectly(mappings: Seq[ControlTypeMapping]): ControlMeasureBuilderImpl = {
+      this.copy(aggregateColumnMappings = mappings)
+    }
+
     def withReportDate(reportDate: String): ControlMeasureBuilderImpl = {
       if (Try(ControlMeasureUtils.dateFormat.parse(reportDate)).isFailure) {
         logger.error(s"Report date $reportDate does not validate against format ${ControlMeasureUtils.dateFormat}." +
@@ -175,13 +184,90 @@ object ControlMeasureBuilder {
       calculateMeasurement()
     }
 
-    def calculateMeasurement(): ControlMeasure = { // scalastyle:off
-      // todo apply selected aggregateControlTypeStrategy. Default = this:
+    /**
+     * Derives control type based on mapping and dataframe. Simply: if mapping contains a specific controlType, it is used.
+     * If it contains Default, the controlType is derived based on column actual type (in df.schema)
+     * @param mapping
+     * @param dataFrame
+     * @return controlType to be used
+     */
+    private[controlmeasure] def deriveControlType(mapping: ControlTypeMapping, dataFrame: DataFrame): ControlType = {
+      val dataType = df.select(mapping.columnName).schema.fields(0).dataType
+      val isNumericDataType = dataType.isInstanceOf[NumericType]
+
+      import ControlType._
+      mapping match {
+        case ControlTypeMapping(columnName, Specific(controlType)) => {
+          if ((controlType == AggregatedTotal || controlType == AbsAggregatedTotal) && !isNumericDataType) {
+            Atum.log.warn(s"Column $columnName measurement $controlType requested, but the field is not numeric!"
+              + s"Found: ${dataType.simpleString} data type.")
+          }
+          controlType // just use the specified controlType
+        }
+        case ControlTypeMapping(_, Default) =>
+          if (isNumericDataType) {
+            AbsAggregatedTotal
+          } else {
+            HashCrc32
+          }
+      }
+    }
+
+    def calculateMeasurement(): ControlMeasure = {
+      // Calculate the measurements
+      val timeStart = getTimestampAsString
+      val rowCount = df.count()
+
+      val aggregatedMeasurements = for (
+        columnMapping <- aggregateColumnMappings
+      ) yield {
+        val columnName = columnMapping.columnName
+        val controlType = deriveControlType(columnMapping, df)
+        def measurementFunction(df: DataFrame): String = MeasurementProcessor.getMeasurementFunction(columnName, controlType)(df)
+
+        Measurement(
+          controlName = columnName + "ControlTotal",
+          controlType = controlType.value,
+          controlCol = columnName,
+          controlValue = measurementFunction(df)
+        )
+      }
+      val timeFinish = getTimestampAsString
+
+      // Create a Control Measurement object
+      ControlMeasure(metadata = ControlMeasureMetadata(
+        sourceApplication = sourceApplication,
+        country = country,
+        historyType = historyType,
+        dataFilename = inputPathName,
+        sourceType = sourceType,
+        version = reportVersion,
+        informationDate = reportDate,
+        additionalInfo = Map[String, String]()
+      ), runUniqueId = None,
+        Checkpoint(
+          name = initialCheckpointName,
+          processStartTime = timeStart,
+          processEndTime = timeFinish,
+          workflowName = workflowName,
+          order = 1,
+          controls = Measurement(
+            controlName = "recordCount",
+            controlType = ControlType.Count.value,
+            controlCol = "*",
+            controlValue = rowCount.toString
+          ) :: aggregatedMeasurements.toList
+        ).withBuildProperties :: Nil)
+    }
+
+    // todo remove when tested to work the same as the above
+    def calculateMeasurementOriginal(): ControlMeasure = { // scalastyle:off
+      // this works as original: as if Default was used
 
       // Calculate the measurements
       val timeStart = getTimestampAsString
       val rowCount = df.count()
-      val aggegatedMeasurements = for (columnName <- aggregateColumns) yield {
+      val aggegatedMeasurements = for (columnName <- aggregateColumnMappings.map(_.columnName)) yield {
         import df.sparkSession.implicits._
 
         val dataType = df.select(columnName).schema.fields(0).dataType

--- a/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtils.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtils.scala
@@ -217,7 +217,7 @@ object ControlMeasureUtils {
    */
   def normalize(controlMeasure: ControlMeasure): ControlMeasure = {
     transformMeasurementInControlMeasure(controlMeasure, measurement => {
-      measurement.copy(controlType = ControlType.getNormalizedStringValue(measurement.controlType))
+      measurement.copy(controlType = ControlType.getNormalizedValueName(measurement.controlType))
     })
   }
 

--- a/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtils.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtils.scala
@@ -217,7 +217,7 @@ object ControlMeasureUtils {
    */
   def normalize(controlMeasure: ControlMeasure): ControlMeasure = {
     transformMeasurementInControlMeasure(controlMeasure, measurement => {
-      measurement.copy(controlType = ControlType.getNormalizedValue(measurement.controlType))
+      measurement.copy(controlType = ControlType.getNormalizedStringValue(measurement.controlType))
     })
   }
 

--- a/atum/src/test/scala/za/co/absa/atum/ControlMeasurementsSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/ControlMeasurementsSpec.scala
@@ -37,7 +37,7 @@ class ControlMeasurementsSpec extends AnyFlatSpec with Matchers with SparkTestBa
       )
     ))
 
-  val measurementsIntOferflow = List(
+  val measurementsIntOverflow = List(
     Measurement(
       controlName = "RecordCount",
       controlType = ControlType.Count.value,
@@ -102,14 +102,14 @@ class ControlMeasurementsSpec extends AnyFlatSpec with Matchers with SparkTestBa
       .schema(schema)
       .json(inputDataJson.toDS)
 
-    val processor = new MeasurementProcessor(measurementsIntOferflow)
+    val processor = new MeasurementProcessor(measurementsIntOverflow)
     val newMeasurements = processor.measureDataset(df)
 
     println(newMeasurements)
 
-    println(measurementsIntOferflow)
+    println(measurementsIntOverflow)
 
-    assert(newMeasurements == measurementsIntOferflow)
+    assert(newMeasurements == measurementsIntOverflow)
   }
 
   val measurementsAggregation = List(

--- a/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilderTest.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilderTest.scala
@@ -19,18 +19,21 @@ import org.apache.spark.sql.DataFrame
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.atum.ControlMeasureBaseTestSuite
+import za.co.absa.atum.core.ControlType
 import za.co.absa.atum.model._
 import za.co.absa.atum.utils.SparkTestBase
+import za.co.absa.atum.utils.controlmeasure.ControlMeasureBuilder.ControlTypeStrategy
 
 class ControlMeasureBuilderTest extends AnyFlatSpec with ControlMeasureBaseTestSuite with SparkTestBase with Matchers {
 
   import spark.implicits._
 
-  val colNames = Seq("col1", "col2")
+  val colNames = Seq("col1", "col2", "col3", "col4")
   val testingDf: DataFrame = Seq(
-    ("example", 11),
-    ("another", 12)
+    ("example", 11, "same", -10),
+    ("another", 12, "same", -10)
   ).toDF(colNames: _*)
+
 
   "ControlMeasureBuilder" should "give default ControlMeasure" in {
     val defaultCm = ControlMeasureBuilder.forDF(testingDf).build
@@ -55,15 +58,15 @@ class ControlMeasureBuilderTest extends AnyFlatSpec with ControlMeasureBaseTestS
     // prior to stabilization, let's check the actual by-default generated software fields:
     defaultCm.checkpoints.map(_.software).foreach { swName =>
       swName shouldBe defined
-      swName.get should fullyMatch regex("""^atum_(2\.11|2\.12)$""")
+      swName.get should fullyMatch regex ("""^atum_(2\.11|2\.12)$""")
     }
 
     defaultCm.stabilizeTestingControlMeasure shouldBe expectedDefaultControlMeasure
   }
 
-  "ControlMeasureBuilder" should "give customized ControlMeasure" in {
+  it should "give customized ControlMeasure" in {
     val customCm = ControlMeasureBuilder.forDF(testingDf)
-      .withAggregateColumns(colNames)
+      .withAggregateColumns(Seq("col1", "col2"))
       .withSourceApplication("SourceApp1")
       .withInputPath("input/path1")
       .withReportDate("2020-10-20")
@@ -98,18 +101,93 @@ class ControlMeasureBuilderTest extends AnyFlatSpec with ControlMeasureBaseTestS
     // prior to stabilization, let's check the actual by-default generated software fields:
     customCm.checkpoints.map(_.software).foreach { swName =>
       swName shouldBe defined
-      swName.get should fullyMatch regex("""^atum_(2\.11|2\.12)$""")
+      swName.get should fullyMatch regex ("""^atum_(2\.11|2\.12)$""")
     }
 
     customCm.stabilizeTestingControlMeasure shouldBe expectedCustomControlMeasure
   }
 
-  "ControlMeasureBuilder" should "refuse incompatible df+columns" in {
+  import ControlTypeStrategy._
+  import ControlType._
+
+  Seq[(String, ControlMeasureBuilder => ControlMeasureBuilder)](
+    ("withAggregateColumns implicit default", _.withAggregateColumns(Seq("col1", "col2"))),
+    ("withAggregateColumns explicit default", _.withAggregateColumns(Seq("col1", "col2"), Default)),
+    ("withAggregateColumn per col - implicit defaults", _.withAggregateColumn("col1").withAggregateColumn("col2")),
+    ("withAggregateColumn per col - explicit defaults",
+      _.withAggregateColumn("col1", Default).withAggregateColumn("col2", Default)),
+    ("withAggregateColumn per col - explicit controlTypes",
+      _.withAggregateColumn("col1", Specific(HashCrc32)).withAggregateColumn("col2", AbsAggregatedTotal))
+  ).foreach { case (testCaseName, aggColsApplication) =>
+
+    it should s"correctly set default-like aggregateColumns ($testCaseName)" in {
+      val customCm = aggColsApplication(ControlMeasureBuilder.forDF(testingDf)).build // one of the .withAggregateColumn(s) above applied
+
+      customCm.checkpoints should have length 1
+      customCm.checkpoints.head.controls should contain theSameElementsAs Seq(
+        Measurement("recordCount", "count", "*", "2"),
+        Measurement("col1ControlTotal", "hashCrc32", "col1", "4497723351"),
+        Measurement("col2ControlTotal", "absAggregatedTotal", "col2", "23")
+      )
+    }
+  }
+
+  it should s"correctly set non-default-like aggregateColumns (count)" in {
+    val customCm = ControlMeasureBuilder
+      .forDF(testingDf)
+      .withAggregateColumn("col1", ControlType.Count)
+      .withAggregateColumn("col1", ControlType.DistinctCount) // totals not tested for non-numeric cols
+      .withAggregateColumn("col1", ControlType.HashCrc32)
+
+      .withAggregateColumn("col2", ControlType.Count)
+      .withAggregateColumn("col2", ControlType.AggregatedTotal)
+      .withAggregateColumn("col2", ControlType.AbsAggregatedTotal)
+      .withAggregateColumn("col2", ControlType.DistinctCount)
+      .withAggregateColumn("col2", ControlType.HashCrc32)
+
+      .withAggregateColumn("col3", ControlType.Count)
+      .withAggregateColumn("col3", ControlType.DistinctCount) // totals not tested for non-numeric cols
+      .withAggregateColumn("col3", ControlType.HashCrc32)
+
+      .withAggregateColumn("col4", ControlType.Count)
+      .withAggregateColumn("col4", ControlType.AggregatedTotal)
+      .withAggregateColumn("col4", ControlType.AbsAggregatedTotal)
+      .withAggregateColumn("col4", ControlType.DistinctCount)
+      .withAggregateColumn("col4", ControlType.HashCrc32)
+      .build
+
+    customCm.checkpoints should have length 1
+    customCm.checkpoints.head.controls should contain theSameElementsAs Seq(
+      Measurement("recordCount", "count", "*", "2"),
+      Measurement("col1ControlTotal", "count", "col1", "2"),
+      Measurement("col1ControlTotal", "distinctCount", "col1", "2"),
+      Measurement("col1ControlTotal", "hashCrc32", "col1", "4497723351"),
+
+      Measurement("col2ControlTotal", "count", "col2", "2"),
+      Measurement("col2ControlTotal", "aggregatedTotal", "col2", "23"),
+      Measurement("col2ControlTotal", "absAggregatedTotal", "col2", "23"),
+      Measurement("col2ControlTotal", "distinctCount", "col2", "2"),
+      Measurement("col2ControlTotal", "hashCrc32", "col2", "4927085124"),
+
+      Measurement("col3ControlTotal", "count", "col3", "2"),
+      Measurement("col3ControlTotal", "distinctCount", "col3", "1"),
+      Measurement("col3ControlTotal", "hashCrc32", "col3", "8466326152"),
+
+      Measurement("col4ControlTotal", "count", "col4", "2"),
+      Measurement("col4ControlTotal", "aggregatedTotal", "col4", "-20"),
+      Measurement("col4ControlTotal", "absAggregatedTotal", "col4", "20"),
+      Measurement("col4ControlTotal", "distinctCount", "col4", "1"),
+      Measurement("col4ControlTotal", "hashCrc32", "col4", "1587574654")
+    )
+  }
+
+  it should "refuse incompatible df+columns" in {
     val message = intercept[IllegalArgumentException] {
       ControlMeasureBuilder.forDF(testingDf).withAggregateColumns(Seq("nonExistentColName"))
     }.getMessage
 
-    message should include("Aggregate columns must be present in dataframe, but 'nonExistentColName' was not found there. Columns found: col1, col2.")
+    message should include
+      "Aggregate columns must be present in dataframe, but 'nonExistentColName' was not found there. Columns found: col1, col2."
   }
 
 }


### PR DESCRIPTION
This PR directly addresses the feature request in #97. In summary, the `ControlMeasurementBuilder` now has a new API for `aggregateColumns` setup (in-depth described in the [README.md](https://github.com/AbsaOSS/atum/pull/107/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R111), too):

```scala

import za.co.absa.atum.utils.controlmeasure.ControlMeasureBuilder
import ControlMeasureBuilder.ControlTypeStrategy.{Default, Specific}
import za.co.absa.atum.core.ControlType.{Count, DistinctCount, AggregatedTotal, AbsAggregatedTotal, HashCrc32}

// controlMeasureBuilder obtainable by ControlMeasureBuilder.forDf(df)
// with Default, the ControlType will be chosen based on the field type (AbsAggregatedTotal for numeric, HashCrc32 otherwise)
val updatedBuilder1 = controlMeasureBuilder.withAggregateColumns(Seq("col1", "col2")) // equivalent to .withAggregateColumns(Seq("col1", "col2"), Default)
val updatedBuilder2 = controlMeasureBuilder.withAggregateColumns(Seq("col1", "col2"), Specific(HashCrc32)) // all columns will use HashCrc32

val iterativelyUpdatedBuilder3 = controlMeasureBuilder
.withAggregateColumn("col1") // equivalent to .withAggregateColumn("col1", Default). AbsAggregatedTotal used if col1 is numeric, HashCrc32 otherwise
.withAggregateColumn("col2", Specific(DistinctCount)) // DistinctCount for this column's measurement
```

## Some implementation details:
 - the original behavior is kept as the `Default` strategy
 - the original behavior duplicated code from MeasurementsProcessor, so MP was split into an object (with general processing methods) and a class (with support for processing based on existing measurements), and the general code was reused for the `ControlMeasurementBuilder `
 - unit tests have been added (existing unit tests show evidence of consistency between the original and the rework)
 - branched from `master` and targeting Atum 3.x - deliberately


