### PR TITLE
Feature/113 info permissions config

### DIFF
--- a/atum/pom.xml
+++ b/atum/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>${typesafe.config.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-scala_${scala.binary.version}</artifactId>
             <version>${mockito.scala.version}</version>
@@ -67,6 +73,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-scala-scalatest_${scala.binary.version}</artifactId>
             <version>${mockito.scala.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minicluster</artifactId>
+            <version>${hadoop.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/atum/src/main/scala/za/co/absa/atum/persistence/hdfs/ControlMeasuresHdfsStorerJsonFile.scala
+++ b/atum/src/main/scala/za/co/absa/atum/persistence/hdfs/ControlMeasuresHdfsStorerJsonFile.scala
@@ -24,7 +24,8 @@ import za.co.absa.atum.utils.HdfsFileUtils
 case class ControlMeasuresHdfsStorerJsonFile(path: Path)(implicit val outputFs: FileSystem) extends HadoopFsControlMeasuresStorer {
   override def store(controlInfo: ControlMeasure): Unit = {
     val serialized =  ControlMeasuresParser asJson controlInfo
-    HdfsFileUtils.saveStringDataToFile(path, serialized, HdfsFileUtils.getInfoFilePermissions())
+    HdfsFileUtils.saveStringDataToFile(path, serialized,
+      HdfsFileUtils.getInfoFilePermissionsFromConfig().getOrElse(HdfsFileUtils.DefaultFilePermissions))
   }
 
   override def getInfo: String = {

--- a/atum/src/main/scala/za/co/absa/atum/persistence/hdfs/ControlMeasuresHdfsStorerJsonFile.scala
+++ b/atum/src/main/scala/za/co/absa/atum/persistence/hdfs/ControlMeasuresHdfsStorerJsonFile.scala
@@ -24,7 +24,7 @@ import za.co.absa.atum.utils.HdfsFileUtils
 case class ControlMeasuresHdfsStorerJsonFile(path: Path)(implicit val outputFs: FileSystem) extends HadoopFsControlMeasuresStorer {
   override def store(controlInfo: ControlMeasure): Unit = {
     val serialized =  ControlMeasuresParser asJson controlInfo
-    HdfsFileUtils.saveStringDataToFile(path, serialized)
+    HdfsFileUtils.saveStringDataToFile(path, serialized, HdfsFileUtils.getInfoFilePermissions())
   }
 
   override def getInfo: String = {

--- a/atum/src/main/scala/za/co/absa/atum/utils/HdfsFileUtils.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/HdfsFileUtils.scala
@@ -26,7 +26,7 @@ import org.apache.spark.SparkContext
 import scala.collection.JavaConverters._
 
 object HdfsFileUtils {
-  val filePermissionsKey = "atum.hdfs.info.file.permissions"
+  final val FilePermissionsKey = "atum.hdfs.info.file.permissions"
 
   private val hadoopConfiguration = SparkContext.getOrCreate().hadoopConfiguration
   private[utils] val defaultFilePermissions = FsPermission.getFileDefault.applyUMask(
@@ -34,8 +34,8 @@ object HdfsFileUtils {
   )
 
   def getInfoFilePermissions(config: Config = ConfigFactory.load()): FsPermission = {
-    if (config.hasPath(filePermissionsKey)) {
-      new FsPermission(config.getString(filePermissionsKey))
+    if (config.hasPath(FilePermissionsKey)) {
+      new FsPermission(config.getString(FilePermissionsKey))
     } else {
       defaultFilePermissions
     }

--- a/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtils.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtils.scala
@@ -183,7 +183,7 @@ object ControlMeasureUtils {
       case JsonType.Pretty => cm.asJsonPretty
     }
 
-    HdfsFileUtils.saveStringDataToFile(infoPath, jsonString)
+    HdfsFileUtils.saveStringDataToFile(infoPath, jsonString, HdfsFileUtils.getInfoFilePermissions())
 
     log.info("Info file written: " + infoPath.toUri.toString)
     log.info("JSON written: " + jsonString)

--- a/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtils.scala
+++ b/atum/src/main/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureUtils.scala
@@ -183,7 +183,8 @@ object ControlMeasureUtils {
       case JsonType.Pretty => cm.asJsonPretty
     }
 
-    HdfsFileUtils.saveStringDataToFile(infoPath, jsonString, HdfsFileUtils.getInfoFilePermissions())
+    HdfsFileUtils.saveStringDataToFile(infoPath, jsonString,
+      HdfsFileUtils.getInfoFilePermissionsFromConfig().getOrElse(HdfsFileUtils.DefaultFilePermissions))
 
     log.info("Info file written: " + infoPath.toUri.toString)
     log.info("JSON written: " + jsonString)

--- a/atum/src/test/scala/za/co/absa/atum/utils/HdfsFileUtilsSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/HdfsFileUtilsSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.utils
+
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HdfsFileUtilsSpec extends AnyFlatSpec with Matchers with SparkTestBase with MiniDfsClusterBase {
+
+  private val Content = "Testing Content"
+
+  "HdfsFileUtils" should "write a file to HDFS (default permissions)" in {
+    val path = new Path("/tmp/hdfs-file-utils-test/def-perms.file")
+    HdfsFileUtils.saveStringDataToFile(path, Content, HdfsFileUtils.getInfoFilePermissions())
+
+    fs.exists(path) shouldBe true
+    fs.getFileStatus(path).getPermission shouldBe HdfsFileUtils.defaultFilePermissions
+    fs.delete(path, true)
+  }
+
+  it should "write a file to HDFS (max permissions)" in {
+    val path = new Path("/tmp/hdfs-file-utils-test/max-perms.file")
+
+    val customConfig = ConfigFactory.empty()
+      .withValue("atum.hdfs.info.file.permissions", ConfigValueFactory.fromAnyRef("777"))
+    HdfsFileUtils.saveStringDataToFile(path, Content, HdfsFileUtils.getInfoFilePermissions(customConfig))
+
+    fs.exists(path) shouldBe true
+    fs.getFileStatus(path).getPermission shouldBe new FsPermission("755") // max for the cluster
+    fs.delete(path, true)
+  }
+
+  it should "write a file to HDFS (min permissions)" in {
+    val path = new Path("/tmp/hdfs-file-utils-test/min-perms.file")
+    val customConfig = ConfigFactory.empty()
+      .withValue("atum.hdfs.info.file.permissions", ConfigValueFactory.fromAnyRef("000"))
+    HdfsFileUtils.saveStringDataToFile(path, Content, HdfsFileUtils.getInfoFilePermissions(customConfig))
+
+    fs.exists(path) shouldBe true
+    fs.getFileStatus(path).getPermission shouldBe new FsPermission("000")
+    fs.delete(path, true)
+  }
+
+}

--- a/atum/src/test/scala/za/co/absa/atum/utils/HdfsFileUtilsSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/HdfsFileUtilsSpec.scala
@@ -76,4 +76,20 @@ class HdfsFileUtilsSpec extends AnyFlatSpec with Matchers with SparkTestBase wit
     fs.deleteOnExit(path)
   }
 
+  Seq(
+    "garbage$55%$",
+    "",
+    "1"
+  ).foreach { invalidFsPermissionString =>
+    it should s"fail on invalid permissions config (case $invalidFsPermissionString)" in {
+      val customConfig = ConfigFactory.empty()
+        .withValue("atum.hdfs.info.file.permissions", ConfigValueFactory.fromAnyRef(invalidFsPermissionString))
+
+      intercept[IllegalArgumentException] {
+        HdfsFileUtils.getInfoFilePermissions(customConfig)
+      }
+    }
+  }
+
+
 }

--- a/atum/src/test/scala/za/co/absa/atum/utils/MiniDfsClusterBase.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/MiniDfsClusterBase.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.atum.utils
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait MiniDfsClusterBase extends BeforeAndAfterAll { this: Suite =>
+
+  private val miniDFSCluster =  new MiniDFSCluster(new Configuration(), 1, true, null);
+  implicit val fs = miniDFSCluster.getFileSystem()
+
+  override def afterAll(): Unit = {
+    miniDFSCluster.shutdown()
+  }
+}

--- a/atum/src/test/scala/za/co/absa/atum/utils/MiniDfsClusterBase.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/MiniDfsClusterBase.scala
@@ -21,7 +21,9 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait MiniDfsClusterBase extends BeforeAndAfterAll { this: Suite =>
 
-  private val miniDFSCluster =  new MiniDFSCluster(new Configuration(), 1, true, null);
+  protected def getConfiguration: Configuration = new Configuration()
+
+  private val miniDFSCluster =  new MiniDFSCluster(getConfiguration, 1, true, null);
   implicit val fs = miniDFSCluster.getFileSystem()
 
   override def afterAll(): Unit = {

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,8 @@
         <aws.java.sdk.version>2.13.65</aws.java.sdk.version>
         <mockito.scala.version>1.15.0</mockito.scala.version>
         <commons.version>0.0.27</commons.version>
+        <typesafe.config.version>1.4.1</typesafe.config.version>
+        <hadoop.version>2.8.5</hadoop.version>
 
         <!-- Spark versions -->
         <spark-24.version>2.4.6</spark-24.version>


### PR DESCRIPTION
Inspired by [Spline](https://github.com/AbsaOSS/spline/blob/release/0.3/persistence/hdfs/src/main/scala/za/co/absa/spline/persistence/hdfs/HdfsPersistenceFactory.scala), Atum now also writes allows setting file permissions to write `_INFO` files to HDFS. If no value is given, the default is derived from local umask, just like in Spline.

The preferred permissions can be given in typesafe config under `atum.hdfs.info.file.permissions`, so e.g.
```yaml
atum.hdfs.info.file.permissions=711
```
(However, please be aware that the resulting permission is limited by local `umask`. (if u mask is `066` and you desire `777` to be written, you only get `711`))

- unit tests using miniDfsCluster, using a custom umask `000` to demonstrate preferred permission ranging from `000` to `777`.

## Test run:
Tested in Enceladus: https://github.com/AbsaOSS/enceladus/pull/1934


