### PR TITLE
Limited publish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,12 +393,13 @@
         </profile>
 
         <profile>
+            <!--
+                Consider calling with publish, e..
+                mvn release:prepare -Dresume=false release:perform -Ppublic -Dlimited
+
+                Profile activation only reacts to properties set externally, not in other profiles (limited property here won't help)
+            -->
             <id>public</id>
-            <modules>
-                <module>atum</module>
-                <module>model</module>
-                <module>atum-s3-sdk-extension</module>
-            </modules>
             <build>
                 <plugins>
                     <plugin>
@@ -430,9 +431,12 @@
             </build>
         </profile>
         <profile>
-            <id>default</id>
+            <id>unlimited</id>
+            <!-- default profile unless property "limited" is supplied via -Dlimited -->
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!limited</name>
+                </property>
             </activation>
             <modules>
                 <module>atum</module>
@@ -442,6 +446,20 @@
                 <module>examples-s3-sdk-extension</module>
             </modules>
         </profile>
+        <profile>
+            <id>limited</id>
+            <activation>
+                <property>
+                    <name>limited</name>
+                </property>
+            </activation>
+            <modules>
+                <module>atum</module>
+                <module>model</module>
+                <module>atum-s3-sdk-extension</module>
+            </modules>
+        </profile>
+
     </profiles>
 
 </project>


### PR DESCRIPTION
**(edit: behaves correctly with -Ppublic & no profile, but with -Pscala-2.11 and similar, it causes problems)**

This PR is a simple way to limit the scope of published modules while keeping all modules available by default for other profiles (even default).

## Publish test run:
Having run the usual `mvn release:prepare -Dresume=false release:perform -Ppublic`, only the selected modules from `public` profile are being published:

![limited-publish](https://user-images.githubusercontent.com/4457378/138070217-c6ad69cd-08c2-4545-8ec8-027a7890343d.png)
(sonatype nexus staging view as evidence, the stage was dropped)

## Plugin config option
Obviously, there seems to be a more natural way to restrict the modules set for publishing, using the staging plugin configuration options (maven profiles are a more general tool). As outlined in [this discussions](https://stackoverflow.com/a/59552811/1773349), such configuration can indeed be used, e.g.
```pom.xml
<plugin>
    <groupId>org.sonatype.plugins</groupId>
    <artifactId>nexus-staging-maven-plugin</artifactId>
    <extensions>true</extensions>
    <configuration>
        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
    </configuration>
</plugin>
```
However, the implementation is weird/buggy, because it only works if the last module is not excluded (which is often the case and incidentally ours, too). This behavior and its workaround are described in issue [NEXUS-9138](https://issues.sonatype.org/browse/NEXUS-9138). Given these imperfections, a simple maven profile setup seemed preferable.


## General remark (e.g. for Atum v4 Experimental API)
The current state of Atum v4 already dealt with `examples` exclusion by moving it into _subproject_ within this repo. However, should we need to be working on an experimental module there (that would not get published), the approach outlined in this PR seems like a viable option.