### PR TITLE
api experimental submodule - restricted from publish

### DIFF
--- a/api-experimental/pom.xml
+++ b/api-experimental/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2018 ABSA Group Limited
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>atum-api-experimental_2.11</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>za.co.absa</groupId>
+        <artifactId>atum-parent_2.11</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <scalastyle.configLocation>${project.parent.basedir}/scalastyle-config.xml</scalastyle.configLocation>
+    </properties>
+
+    <dependencies>
+        <!-- Atum model -->
+        <dependency>
+            <groupId>za.co.absa</groupId>
+            <artifactId>atum-model_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <directory>${project.basedir}/target/${scala.binary.version}</directory>
+        <outputDirectory>${project.build.directory}/classes</outputDirectory>
+        <testOutputDirectory>${project.build.directory}/test-classes</testOutputDirectory>
+
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.scalastyle</groupId>
+                <artifactId>scalastyle-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <properties>
+                <scala.binary.version>2.11</scala.binary.version>
+                <scala.version>${scala_2.11.version}</scala.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.12</id>
+            <properties>
+                <scala.binary.version>2.12</scala.binary.version>
+                <scala.version>${scala_2.12.version}</scala.version>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,6 @@
 
     <packaging>pom</packaging>
 
-    <modules>
-        <module>model</module>
-        <module>atum</module>
-        <module>atum-s3-sdk-extension</module>
-    </modules>
 
     <name>Atum</name>
     <description>Dynamic data completeness and accuracy at enterprise scale in Apache Spark</description>
@@ -430,6 +425,11 @@
 
         <profile>
             <id>public</id>
+            <modules>
+                <module>atum</module>
+                <module>model</module>
+                <module>atum-s3-sdk-extension</module>
+            </modules>
             <build>
                 <plugins>
                     <plugin>
@@ -459,6 +459,18 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>model</module>
+                <module>atum</module>
+                <module>atum-s3-sdk-extension</module>
+                <module>api-experimental</module>
+            </modules>
         </profile>
     </profiles>
 


### PR DESCRIPTION
This small PR introduces a blank submodule `api-experimental` and limits the release process using the same approach as in #115, hence this new submodule is not included in the release process.

**edit: closed due to unsatisfactory result of #115** 