### PR TITLE
Add support for Scala 2.13

### DIFF
--- a/.github/workflows/build-sbt.yml
+++ b/.github/workflows/build-sbt.yml
@@ -27,12 +27,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [ 2.11.12, 2.12.15 ]
+        scala: [ 2.11.12, 2.12.15, 2.13.14 ]
         spark: [ 2.4.8, 3.2.2 ]
         exclude:
           - scala: 2.11.12
             spark: 3.2.2
           - scala: 2.12.15
+            spark: 2.4.8
+          - scala: 2.13.14
             spark: 2.4.8
     name: SBT Spark ${{matrix.spark}} on Scala ${{matrix.scala}}
     steps:

--- a/.github/workflows/build-sbt.yml
+++ b/.github/workflows/build-sbt.yml
@@ -40,9 +40,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - uses: coursier/cache-action@v5
+      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 #v8.1.0
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
+        uses: olafurpg/setup-scala@32ffa16635ff8f19cc21ea253a987f0fdf29844c #v14
         with:
           java-version: "adopt@1.8"
       - name: Build and run tests

--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -37,6 +37,11 @@ jobs:
             spark: 3.2.2
             overall: 0.0
             changed: 80.0
+          - scala: 2.13.14
+            scala_short: 2.13
+            spark: 3.2.2
+            overall: 0.0
+            changed: 80.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ For project using Scala 2.12
     <version>ATUM_VERSION_HERE</version>
 </dependency>
 ```
+For project using Scala 2.13
+```xml
+<dependency>
+    <groupId>za.co.absa</groupId>
+    <artifactId>atum_2.13</artifactId>
+    <version>ATUM_VERSION_HERE</version>
+</dependency>
+```
 
 ### Initial info file generation example
 
@@ -305,7 +313,7 @@ Starting with version 3.3.0, there is also persistence support for AWS S3 via AW
 ```xml
 <dependency>
     <groupId>za.co.absa</groupId>
-    <artifactId>atum-s3-sdk-extension_2.11</artifactId> <!-- or 2.12 -->
+    <artifactId>atum-s3-sdk-extension_2.11</artifactId> <!-- or 2.12 / 2.13 -->
     <version>${project.version}</version> <!-- e.g. 3.3.0 -->
 </dependency>
 ```
@@ -361,13 +369,13 @@ with `3.5.3` and `3.7.0-M15`.
 ```xml
 <dependency>
     <groupId>org.json4s</groupId>
-    <artifactId>json4s-core_2.11</artifactId> <!-- or 2.12 -->
+    <artifactId>json4s-core_2.11</artifactId> <!-- or 2.12 / 2.13 -->
     <version>${json4s.version}</version>
     <scope>provided</scope>
 </dependency>
 <dependency>
     <groupId>org.json4s</groupId>
-    <artifactId>json4s-jackson_2.11</artifactId> <!-- or 2.12 -->
+    <artifactId>json4s-jackson_2.11</artifactId> <!-- or 2.12 / 2.13 -->
     <version>${json4s.version}</version>
     <scope>provided</scope>
 </dependency>
@@ -377,7 +385,7 @@ Then, just include the model library
 ```xml
 <dependency>
     <groupId>za.co.absa</groupId>
-    <artifactId>atum-model_2.11</artifactId> <!-- or 2.12 -->
+    <artifactId>atum-model_2.11</artifactId> <!-- or 2.12 / 2.13 -->
     <version>3.5.1</version>
 </dependency>
 ```

--- a/atum/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/atum/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,1 @@
-mock-maker-inline
+org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker

--- a/atum/src/test/scala/za/co/absa/atum/utils/BuildPropertiesSpec.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/BuildPropertiesSpec.scala
@@ -34,6 +34,6 @@ class BuildPropertiesSpec extends AnyFlatSpec  {
   }
 
   "Project Name" should "start with atum and scala version" in {
-    assert(name.matches("""^atum_(2\.11|2\.12)$"""))
+    assert(name.matches("""^atum_(2\.11|2\.12|2\.13)$"""))
   }
 }

--- a/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilderTest.scala
+++ b/atum/src/test/scala/za/co/absa/atum/utils/controlmeasure/ControlMeasureBuilderTest.scala
@@ -58,7 +58,7 @@ class ControlMeasureBuilderTest extends AnyFlatSpec with ControlMeasureBaseTestS
     // prior to stabilization, let's check the actual by-default generated software fields:
     defaultCm.checkpoints.map(_.software).foreach { swName =>
       swName shouldBe defined
-      swName.get should fullyMatch regex ("""^atum_(2\.11|2\.12)$""")
+      swName.get should fullyMatch regex ("""^atum_(2\.11|2\.12|2\.13)$""")
     }
 
     defaultCm.stabilizeTestingControlMeasure shouldBe expectedDefaultControlMeasure
@@ -101,7 +101,7 @@ class ControlMeasureBuilderTest extends AnyFlatSpec with ControlMeasureBaseTestS
     // prior to stabilization, let's check the actual by-default generated software fields:
     customCm.checkpoints.map(_.software).foreach { swName =>
       swName shouldBe defined
-      swName.get should fullyMatch regex ("""^atum_(2\.11|2\.12)$""")
+      swName.get should fullyMatch regex ("""^atum_(2\.11|2\.12|2\.13)$""")
     }
 
     customCm.stabilizeTestingControlMeasure shouldBe expectedCustomControlMeasure

--- a/build.sbt
+++ b/build.sbt
@@ -22,9 +22,10 @@ import com.github.sbt.jacoco.report.JacocoReportSettings
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.15"
+lazy val scala213 = "2.13.14"
 
 ThisBuild / scalaVersion := scala211  // default version
-ThisBuild / crossScalaVersions := Seq(scala211, scala212)
+ThisBuild / crossScalaVersions := Seq(scala211, scala212, scala213)
 
 lazy val printSparkScalaVersion = taskKey[Unit]("Print Spark and Scala versions that Atum is being built for.")
 ThisBuild / printSparkScalaVersion := {

--- a/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
+++ b/examples/src/test/scala/za/co/absa/atum/HdfsInfoIntegrationSuite.scala
@@ -22,17 +22,14 @@ import org.apache.log4j.LogManager
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
-import org.scalatest.flatspec.{AnyFlatSpec, AsyncFlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.specs2.matcher.Matchers.concurrentExecutionContext
 import za.co.absa.atum.model.{Checkpoint, Measurement}
 import za.co.absa.atum.persistence.ControlMeasuresParser
 import za.co.absa.atum.utils.SparkTestBase
 import za.co.absa.atum.AtumImplicits._
 
-import scala.concurrent.duration.{Duration, DurationInt}
-import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.DurationInt
 
 class HdfsInfoIntegrationSuite extends AnyFlatSpec with SparkTestBase with Matchers with BeforeAndAfterAll with Eventually {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,18 +20,14 @@ object Dependencies {
   object Versions {
     val spark2 = "2.4.8"
     val spark3 = "3.2.2"
-    val spark3_213 = "3.5.1"
 
     val json4s_spark2 = "3.5.3"
     val json4s_spark3 = "3.7.0-M11"
-    val json4s_spark3_213 = json4s_spark3
 
     val jacksonModuleScala_spark2 = "2.12.7"
     val jacksonModuleScala_spark3 = "2.14.1"
-    val jacksonModuleScala_spark3_213 = jacksonModuleScala_spark3
     val jacksonDatabind_spark2 = "2.12.7.1" // databind has extra extra patch for this version - for Spark2
     val jacksonDatabind_spark3 = jacksonModuleScala_spark3 // for Spark3 - latest version is ok
-    val jacksonDatabind_spark3_213 = jacksonModuleScala_spark3_213
 
     val absaCommons = "2.0.4"
     val typesafeConfig = "1.4.1"
@@ -50,7 +46,7 @@ object Dependencies {
     scalaVersion match {
       case _ if scalaVersion.startsWith("2.11") => Versions.spark2
       case _ if scalaVersion.startsWith("2.12") => Versions.spark3
-      case _ if scalaVersion.startsWith("2.13") => Versions.spark3_213
+      case _ if scalaVersion.startsWith("2.13") => Versions.spark3
       case _ => throw new IllegalArgumentException("Only Scala 2.11, 2.12 and 2.13 are currently supported.")
     }
   }
@@ -85,20 +81,20 @@ object Dependencies {
     ) exclude(
       "com.fasterxml.jackson.module", "jackson-module-scala_" + scalaVersion.substring(0, 4)  // e.g. 2.11
     )
-    moduleByScalaUsingScalaVersion(coreWithExcludes)(Versions.spark2, Versions.spark3, Versions.spark3_213) _
+    moduleByScalaUsingScalaVersion(coreWithExcludes)(Versions.spark2, Versions.spark3, Versions.spark3) _
   }
 
-  lazy val sparkSql = moduleByScala("org.apache.spark" %% "spark-sql" % _ % Provided)(Versions.spark2, Versions.spark3, Versions.spark3_213) _
+  lazy val sparkSql = moduleByScala("org.apache.spark" %% "spark-sql" % _ % Provided)(Versions.spark2, Versions.spark3, Versions.spark3) _
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalatest % Test
 
-  lazy val json4sExt = moduleByScala("org.json4s" %% "json4s-ext" % _)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3_213) _
-  lazy val json4sCore = moduleByScala("org.json4s" %% "json4s-core" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3_213) _
-  lazy val json4sJackson = moduleByScala("org.json4s" %% "json4s-jackson" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3_213) _
-  lazy val json4sNative = moduleByScala("org.json4s" %% "json4s-native" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3_213) _
+  lazy val json4sExt = moduleByScala("org.json4s" %% "json4s-ext" % _)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3) _
+  lazy val json4sCore = moduleByScala("org.json4s" %% "json4s-core" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3) _
+  lazy val json4sJackson = moduleByScala("org.json4s" %% "json4s-jackson" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3) _
+  lazy val json4sNative = moduleByScala("org.json4s" %% "json4s-native" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3) _
 
-  lazy val jacksonModuleScala = moduleByScala("com.fasterxml.jackson.module" %% "jackson-module-scala" % _)(Versions.jacksonModuleScala_spark2, Versions.jacksonModuleScala_spark3, Versions.jacksonModuleScala_spark3_213) _
-  lazy val jacksonDatabind = moduleByScala("com.fasterxml.jackson.core" % "jackson-databind" % _)(Versions.jacksonDatabind_spark2, Versions.jacksonDatabind_spark3, Versions.jacksonDatabind_spark3_213) _
+  lazy val jacksonModuleScala = moduleByScala("com.fasterxml.jackson.module" %% "jackson-module-scala" % _)(Versions.jacksonModuleScala_spark2, Versions.jacksonModuleScala_spark3, Versions.jacksonModuleScala_spark3) _
+  lazy val jacksonDatabind = moduleByScala("com.fasterxml.jackson.core" % "jackson-databind" % _)(Versions.jacksonDatabind_spark2, Versions.jacksonDatabind_spark3, Versions.jacksonDatabind_spark3) _
 
   lazy val absaCommons = "za.co.absa.commons" %% "commons" % Versions.absaCommons
   lazy val commonsConfiguration = "commons-configuration" % "commons-configuration" % Versions.commonsConfiguration

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,20 +20,23 @@ object Dependencies {
   object Versions {
     val spark2 = "2.4.8"
     val spark3 = "3.2.2"
+    val spark3_213 = "3.5.1"
 
     val json4s_spark2 = "3.5.3"
     val json4s_spark3 = "3.7.0-M11"
+    val json4s_spark3_213 = json4s_spark3
 
     val jacksonModuleScala_spark2 = "2.12.7"
     val jacksonModuleScala_spark3 = "2.14.1"
+    val jacksonModuleScala_spark3_213 = jacksonModuleScala_spark3
     val jacksonDatabind_spark2 = "2.12.7.1" // databind has extra extra patch for this version - for Spark2
     val jacksonDatabind_spark3 = jacksonModuleScala_spark3 // for Spark3 - latest version is ok
+    val jacksonDatabind_spark3_213 = jacksonModuleScala_spark3_213
 
-    val absaCommons = "0.0.27"
+    val absaCommons = "2.0.4"
     val typesafeConfig = "1.4.1"
     val mockitoScala = "1.17.12"
     val scalatest = "3.2.9"
-    val specs2 = "2.5"
     val aws = "2.17.85"
 
     val apacheCommonsLang3 = "3.12.0"
@@ -47,33 +50,34 @@ object Dependencies {
     scalaVersion match {
       case _ if scalaVersion.startsWith("2.11") => Versions.spark2
       case _ if scalaVersion.startsWith("2.12") => Versions.spark3
-      case _ => throw new IllegalArgumentException("Only Scala 2.11 and 2.12 are currently supported.")
+      case _ if scalaVersion.startsWith("2.13") => Versions.spark3_213
+      case _ => throw new IllegalArgumentException("Only Scala 2.11, 2.12 and 2.13 are currently supported.")
     }
   }
 
-  // general wrapper to simplify s2.11/2.12 version assigning
+  // general wrapper to simplify s2.11/2.12/2.13 version assigning
   def moduleByScala(moduleIdWithoutVersion: String => ModuleID)
-                   (scala211Version: String, scala212Version: String)
+                   (scala211Version: String, scala212Version: String, scala213Version: String)
                    (actualScalaVersion: String): ModuleID = {
     actualScalaVersion match {
-      case _ if actualScalaVersion.startsWith("2.11") => moduleIdWithoutVersion.apply(scala211Version)
-      case _ if actualScalaVersion.startsWith("2.12") => moduleIdWithoutVersion.apply(scala212Version)
-      case _ => throw new IllegalArgumentException("Only Scala 2.11 and 2.12 are currently supported.")
+      case _ if actualScalaVersion.startsWith("2.11") => moduleIdWithoutVersion(scala211Version)
+      case _ if actualScalaVersion.startsWith("2.12") => moduleIdWithoutVersion(scala212Version)
+      case _ if actualScalaVersion.startsWith("2.13") => moduleIdWithoutVersion(scala213Version)
+      case _ => throw new IllegalArgumentException("Only Scala 2.11, 2.12 and 2.13 are currently supported.")
     }
   }
-
 
   // extended version where to moduleId Fn takes 2 params: module version and scala version (to pass along)
   def moduleByScalaUsingScalaVersion(moduleIdWithoutVersionNeedsScalaVersion: (String, String) => ModuleID)
-                                    (scala211Version: String, scala212Version: String)
+                                    (scala211Version: String, scala212Version: String, scala213Version: String)
                                     (actualScalaVersion: String): ModuleID = {
     actualScalaVersion match {
-      case _ if actualScalaVersion.startsWith("2.11") => moduleIdWithoutVersionNeedsScalaVersion.apply(scala211Version, actualScalaVersion)
-      case _ if actualScalaVersion.startsWith("2.12") => moduleIdWithoutVersionNeedsScalaVersion.apply(scala212Version, actualScalaVersion)
-      case _ => throw new IllegalArgumentException("Only Scala 2.11 and 2.12 are currently supported.")
+      case _ if actualScalaVersion.startsWith("2.11") => moduleIdWithoutVersionNeedsScalaVersion(scala211Version, actualScalaVersion)
+      case _ if actualScalaVersion.startsWith("2.12") => moduleIdWithoutVersionNeedsScalaVersion(scala212Version, actualScalaVersion)
+      case _ if actualScalaVersion.startsWith("2.13") => moduleIdWithoutVersionNeedsScalaVersion(scala213Version, actualScalaVersion)
+      case _ => throw new IllegalArgumentException("Only Scala 2.11, 2.12 and 2.13 are currently supported.")
     }
   }
-
 
   lazy val sparkCore = {
     def coreWithExcludes(version: String, scalaVersion: String): ModuleID = "org.apache.spark" %% "spark-core" % version % Provided exclude(
@@ -81,20 +85,20 @@ object Dependencies {
     ) exclude(
       "com.fasterxml.jackson.module", "jackson-module-scala_" + scalaVersion.substring(0, 4)  // e.g. 2.11
     )
-    moduleByScalaUsingScalaVersion(coreWithExcludes)(Versions.spark2, Versions.spark3) _
+    moduleByScalaUsingScalaVersion(coreWithExcludes)(Versions.spark2, Versions.spark3, Versions.spark3_213) _
   }
 
-  lazy val sparkSql = moduleByScala("org.apache.spark" %% "spark-sql" % _ % Provided)(Versions.spark2, Versions.spark3) _
+  lazy val sparkSql = moduleByScala("org.apache.spark" %% "spark-sql" % _ % Provided)(Versions.spark2, Versions.spark3, Versions.spark3_213) _
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalatest % Test
 
-  lazy val json4sExt = moduleByScala("org.json4s" %% "json4s-ext" % _)(Versions.json4s_spark2, Versions.json4s_spark3) _
-  lazy val json4sCore = moduleByScala("org.json4s" %% "json4s-core" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3) _
-  lazy val json4sJackson = moduleByScala("org.json4s" %% "json4s-jackson" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3) _
-  lazy val json4sNative = moduleByScala("org.json4s" %% "json4s-native" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3) _
+  lazy val json4sExt = moduleByScala("org.json4s" %% "json4s-ext" % _)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3_213) _
+  lazy val json4sCore = moduleByScala("org.json4s" %% "json4s-core" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3_213) _
+  lazy val json4sJackson = moduleByScala("org.json4s" %% "json4s-jackson" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3_213) _
+  lazy val json4sNative = moduleByScala("org.json4s" %% "json4s-native" % _ % Provided)(Versions.json4s_spark2, Versions.json4s_spark3, Versions.json4s_spark3_213) _
 
-  lazy val jacksonModuleScala = moduleByScala("com.fasterxml.jackson.module" %% "jackson-module-scala" % _)(Versions.jacksonModuleScala_spark2, Versions.jacksonModuleScala_spark3) _
-  lazy val jacksonDatabind = moduleByScala("com.fasterxml.jackson.core" % "jackson-databind" % _)(Versions.jacksonDatabind_spark2, Versions.jacksonDatabind_spark3) _
+  lazy val jacksonModuleScala = moduleByScala("com.fasterxml.jackson.module" %% "jackson-module-scala" % _)(Versions.jacksonModuleScala_spark2, Versions.jacksonModuleScala_spark3, Versions.jacksonModuleScala_spark3_213) _
+  lazy val jacksonDatabind = moduleByScala("com.fasterxml.jackson.core" % "jackson-databind" % _)(Versions.jacksonDatabind_spark2, Versions.jacksonDatabind_spark3, Versions.jacksonDatabind_spark3_213) _
 
   lazy val absaCommons = "za.co.absa.commons" %% "commons" % Versions.absaCommons
   lazy val commonsConfiguration = "commons-configuration" % "commons-configuration" % Versions.commonsConfiguration
@@ -105,8 +109,6 @@ object Dependencies {
   lazy val mockitoScalaScalatest = "org.mockito" %% "mockito-scala-scalatest" % Versions.mockitoScala % Test
 
   lazy val scalaTestProvided = "org.scalatest" %% "scalatest" % Versions.scalatest % Provided
-  lazy val specs2core = "org.specs2" %% "specs2-core" % Versions.specs2 % Test
-
   lazy val sdkS3 = "software.amazon.awssdk" % "s3" % Versions.aws
 
   def rootDependencies(scalaVersion: String): Seq[ModuleID] = Seq(
@@ -135,7 +137,6 @@ object Dependencies {
   )
 
   lazy val examplesDependencies: Seq[ModuleID] = Seq(
-    specs2core,
     scalaTestProvided
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 
-sbt.version = 1.5.5
+sbt.version = 1.9.9


### PR DESCRIPTION
This pull request adds support for Scala 2.13 across the project, updating documentation, build configuration, and dependency handling to ensure compatibility. It also updates some dependency versions and cleans up test and example configurations.

**Scala 2.13 support and dependency updates:**

* Updated `project/Dependencies.scala` to support Scala 2.13 in dependency resolution, including Spark, json4s, and Jackson modules. Added new version constants for Scala 2.13 and improved helper functions to handle three Scala versions. Also updated the `absaCommons` dependency version. [[1]](diffhunk://#diff-ad2642dc77b3679e4ad2c7d3b2f59a2dcf48c1bf5b93a558a4fa44828315a34cR23-L36) [[2]](diffhunk://#diff-ad2642dc77b3679e4ad2c7d3b2f59a2dcf48c1bf5b93a558a4fa44828315a34cL50-R101)
* Updated the `README.md` to document usage and dependency examples for Scala 2.13, including for core, S3 extension, json4s, and model modules. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R115) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L308-R316) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L364-R378) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L380-R388)

**Build and test configuration:**

* Upgraded `sbt` version in `project/build.properties` from 1.5.5 to 1.9.9 for better Scala 2.13 support.
* Modified test regex patterns in `BuildPropertiesSpec.scala` and `ControlMeasureBuilderTest.scala` to accept Scala 2.13 artifact names. [[1]](diffhunk://#diff-39c219c47054ea55e69322b25b7acb6998d1c814a102610840d3519f4c46e18eL37-R37) [[2]](diffhunk://#diff-4a88f12222e1d65fb38fba4aa4009be90bcb38c0119a8e27354a86120d8c7d39L61-R61) [[3]](diffhunk://#diff-4a88f12222e1d65fb38fba4aa4009be90bcb38c0119a8e27354a86120d8c7d39L104-R104)
* Changed the Mockito mock maker configuration in test resources to use `SubclassByteBuddyMockMaker` instead of `mock-maker-inline`, likely for better compatibility.

**Cleanup and simplification:**

* Removed unused or redundant imports and dependencies from the example and test configurations, including dropping `specs2` in favor of `scalatest` for examples. [[1]](diffhunk://#diff-5c4669f8c5cf9d6310f9b09fc41b10a82b6ed444ee48f75c2e5efdd6804b6607L25-R32) [[2]](diffhunk://#diff-ad2642dc77b3679e4ad2c7d3b2f59a2dcf48c1bf5b93a558a4fa44828315a34cL108-L109) [[3]](diffhunk://#diff-ad2642dc77b3679e4ad2c7d3b2f59a2dcf48c1bf5b93a558a4fa44828315a34cL138)